### PR TITLE
tesseract_rviz port again

### DIFF
--- a/tesseract_monitoring/src/environment_monitor.cpp
+++ b/tesseract_monitoring/src/environment_monitor.cpp
@@ -343,24 +343,36 @@ void EnvironmentMonitor::stopPublishingEnvironment()
 
 void EnvironmentMonitor::startPublishingEnvironment()
 {
-  if (!publish_environment_ && env_->isInitialized())
+  rclcpp::Logger logger = node_->get_logger().get_child(monitor_namespace_ + "_monitor");
+  if (publish_environment_)
   {
-    std::string environment_topic = R"(/)" + monitor_namespace_ + DEFAULT_PUBLISH_ENVIRONMENT_TOPIC;
-    environment_publisher_ = node_->create_publisher<tesseract_msgs::msg::EnvironmentState>(
-        environment_topic, rclcpp::QoS(100));
-    RCLCPP_INFO(node_->get_logger().get_child(monitor_namespace_),
-        "Publishing maintained environment on '%s'", environment_topic.c_str());
-    publish_environment_ =
-        std::make_unique<std::thread>(std::bind(&EnvironmentMonitor::environmentPublishingThread, this));
+    RCLCPP_ERROR(logger, "Environment publishing thread already exists!");
+    return;
   }
+  if (! env_->isInitialized())
+  {
+    RCLCPP_ERROR(logger, "Tesseract environment not initialized, can't publish environment!");
+    return;
+  }
+
+  std::string environment_topic = R"(/)" + monitor_namespace_ + DEFAULT_PUBLISH_ENVIRONMENT_TOPIC;
+  environment_publisher_ = node_->create_publisher<tesseract_msgs::msg::EnvironmentState>(
+      environment_topic, rclcpp::QoS(100));
+  RCLCPP_INFO(logger, "Publishing maintained environment on '%s'", environment_topic.c_str());
+  publish_environment_ = std::make_unique<std::thread>(
+      [this]()
+      {
+        environmentPublishingThread();
+      }
+  );
 }
 
 double EnvironmentMonitor::getEnvironmentPublishingFrequency() const { return publish_environment_frequency_; }
 
 void EnvironmentMonitor::environmentPublishingThread()
 {
-  RCLCPP_DEBUG(node_->get_logger().get_child(monitor_namespace_),
-    "Started environment state publishing thread ...");
+  rclcpp::Logger logger = node_->get_logger().get_child(monitor_namespace_ + "_monitor");
+  RCLCPP_INFO(logger, "Started environment state publishing thread ...");
 
   // publish the full planning scene
   tesseract_msgs::msg::EnvironmentState start_msg;
@@ -370,8 +382,7 @@ void EnvironmentMonitor::environmentPublishingThread()
   std::this_thread::sleep_for(std::chrono::duration<double>(1.5));
   environment_publisher_->publish(start_msg);
 
-  RCLCPP_DEBUG(node_->get_logger().get_child(monitor_namespace_),
-    "Published the Tesseract Environment State for: '%s'", start_msg.id.c_str());
+  RCLCPP_INFO(logger, "Published the Tesseract Environment State for: '%s'", start_msg.id.c_str());
 
   do
   {
@@ -394,6 +405,8 @@ void EnvironmentMonitor::environmentPublishingThread()
       rate.sleep();
     }
   } while (publish_environment_);
+
+  RCLCPP_INFO(logger, "Stopping env publishing thread");
 }
 
 CurrentStateMonitor::ConstPtr EnvironmentMonitor::getStateMonitor() const { return current_state_monitor_; }

--- a/tesseract_ros_examples/config/examples.rviz
+++ b/tesseract_ros_examples/config/examples.rviz
@@ -6,6 +6,8 @@ Panels:
       Expanded:
         - /Global Options1
         - /Status1
+        - /EnvironmentState1
+        - /TesseractTrajectory1
       Splitter Ratio: 0.5
     Tree Height: 1464
   - Class: rviz_common/Selection
@@ -43,6 +45,121 @@ Visualization Manager:
       Reference Frame: <Fixed Frame>
       Value: true
     - Class: tesseract_rviz/EnvironmentState
+      Enabled: false
+      Environment:
+        Alpha: 1
+        Display Mode: URDF
+        Show All Links: true
+        Show Collision: false
+        Show Highlights: true
+        Show Visual: true
+        URDF Description: robot_description
+        URDF Parameter: robot_description
+        Value: ""
+      Joint State Monitor:
+        Topic: joint_states
+        Value: ""
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ee_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ee_mount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        grinder_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        grinder_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_7:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_grinder:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        link_grinder_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        part:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        table:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        tool0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        tool1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Name: EnvironmentState
+      Value: false
+    - Class: tesseract_rviz/TesseractTrajectory
       Enabled: true
       Environment:
         Alpha: 1
@@ -58,13 +175,113 @@ Visualization Manager:
         Topic: joint_states
         Value: ""
       Links:
-        All Links Enabled:
-          {}
+        All Links Enabled: true
         Expand Joint Details: false
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
-      Name: EnvironmentState
+        base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ee_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ee_mount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        grinder_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        grinder_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_7:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_grinder:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        link_grinder_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        part:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        table:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        tool0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        tool1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Name: TesseractTrajectory
+      Trajectory Monitor:
+        Topic: /tesseract/display_tesseract_trajectory
+        Value: ""
+      Trajectory Visualization:
+        Display Mode: Loop
+        Interrupt Display: false
+        Time Scale: 1
+        Trail Step Size: 1
+        Value: ""
       Value: true
   Enabled: true
   Global Options:
@@ -130,12 +347,14 @@ Visualization Manager:
       Yaw: 0.785398006439209
     Saved: ~
 Window Geometry:
+  " - Slider":
+    collapsed: false
   Displays:
     collapsed: false
   Height: 1733
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000001650000065afc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000007300fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c00610079007301000000490000065a000000fb00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f0000065afc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007301000000490000065a000000c900fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000006270000065a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001da0000065afc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000007300fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c00610079007301000000490000065a000000fb00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000120020002d00200053006c00690064006500720000000000ffffffff0000004f00ffffff000000010000010f0000065afc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007301000000490000065a000000c900fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000005b20000065a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Tool Properties:

--- a/tesseract_ros_examples/config/examples.rviz
+++ b/tesseract_ros_examples/config/examples.rviz
@@ -1,48 +1,32 @@
 Panels:
-  - Class: rviz/Displays
-    Help Height: 78
+  - Class: rviz_common/Displays
+    Help Height: 89
     Name: Displays
     Property Tree Widget:
       Expanded:
         - /Global Options1
-        - /TesseractTrajectory1
-        - /TesseractTrajectory1/Environment1
-        - /TesseractTrajectory1/Joint State Monitor1
-        - /TesseractTrajectory1/Trajectory Monitor1
-        - /CollisionMarkers1
-        - /EnvironmentState1/Environment1
-        - /Toolpath1
-      Splitter Ratio: 0.5077950954437256
-    Tree Height: 476
-  - Class: rviz/Selection
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 1464
+  - Class: rviz_common/Selection
     Name: Selection
-  - Class: rviz/Tool Properties
+  - Class: rviz_common/Tool Properties
     Expanded:
-      - /2D Pose Estimate1
-      - /2D Nav Goal1
+      - /2D Goal Pose1
       - /Publish Point1
     Name: Tool Properties
     Splitter Ratio: 0.5886790156364441
-  - Class: rviz/Views
+  - Class: rviz_common/Views
     Expanded:
       - /Current View1
     Name: Views
     Splitter Ratio: 0.5
-  - Class: rviz/Time
-    Experimental: false
-    Name: Time
-    SyncMode: 0
-    SyncSource: ""
-Preferences:
-  PromptSaveOnExit: true
-Toolbars:
-  toolButtonStyle: 2
 Visualization Manager:
   Class: ""
   Displays:
     - Alpha: 0.5
       Cell Size: 1
-      Class: rviz/Grid
+      Class: rviz_default_plugins/Grid
       Color: 160; 160; 164
       Enabled: true
       Line Style:
@@ -58,59 +42,20 @@ Visualization Manager:
       Plane Cell Count: 10
       Reference Frame: <Fixed Frame>
       Value: true
-    - Class: tesseract_rviz/TesseractTrajectory
-      Enabled: true
-      Environment:
-        Alpha: 1
-        Display Mode: Monitor
-        Monitor Namespace: tesseract_ros_examples
-        Show All Links: true
-        Show Collision: false
-        Show Highlights: true
-        Show Visual: true
-        Value: ""
-      Joint State Monitor:
-        Topic: /joint_states
-        Value: ""
-      Links:
-        All Links Enabled:
-          {}
-        Expand Joint Details: false
-        Expand Link Details: false
-        Expand Tree: false
-        Link Tree Style: Links in Alphabetic Order
-      Name: TesseractTrajectory
-      Trajectory Monitor:
-        Topic: /tesseract/display_tesseract_trajectory
-        Value: ""
-      Trajectory Visualization:
-        Display Mode: Loop
-        Interrupt Display: false
-        Time Scale: 1
-        Trail Step Size: 1
-        Value: ""
-      Value: true
-    - Class: rviz/MarkerArray
-      Enabled: true
-      Marker Topic: /tesseract/display_collisions
-      Name: CollisionMarkers
-      Namespaces:
-        {}
-      Queue Size: 100
-      Value: true
     - Class: tesseract_rviz/EnvironmentState
       Enabled: true
       Environment:
         Alpha: 1
-        Display Mode: Monitor
-        Monitor Namespace: tesseract_ros_examples
+        Display Mode: URDF
         Show All Links: true
         Show Collision: false
         Show Highlights: true
         Show Visual: true
+        URDF Description: robot_description
+        URDF Parameter: robot_description
         Value: ""
       Joint State Monitor:
-        Topic: /joint_states
+        Topic: joint_states
         Value: ""
       Links:
         All Links Enabled:
@@ -121,79 +66,82 @@ Visualization Manager:
         Link Tree Style: Links in Alphabetic Order
       Name: EnvironmentState
       Value: true
-    - Class: rviz/MarkerArray
-      Enabled: true
-      Marker Topic: /tesseract/display_tool_path
-      Name: Toolpath
-      Namespaces:
-        {}
-      Queue Size: 100
-      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Default Light: true
     Fixed Frame: world
     Frame Rate: 30
   Name: root
   Tools:
-    - Class: rviz/Interact
+    - Class: rviz_default_plugins/Interact
       Hide Inactive Objects: true
-    - Class: rviz/MoveCamera
-    - Class: rviz/Select
-    - Class: rviz/FocusCamera
-    - Class: rviz/Measure
-    - Class: rviz/SetInitialPose
-      Theta std deviation: 0.2617993950843811
-      Topic: /initialpose
-      X std deviation: 0.5
-      Y std deviation: 0.5
-    - Class: rviz/SetGoal
-      Topic: /move_base_simple/goal
-    - Class: rviz/PublishPoint
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
       Single click: true
-      Topic: /clicked_point
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
   Value: true
   Views:
     Current:
-      Class: rviz/Orbit
-      Distance: 8.752453804016113
+      Class: rviz_default_plugins/Orbit
+      Distance: 10
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
-      Field of View: 0.7853981852531433
       Focal Point:
-        X: -0.0302668958902359
-        Y: 0.4337078928947449
-        Z: 0.32609304785728455
+        X: 0
+        Y: 0
+        Z: 0
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.44039809703826904
+      Pitch: 0.785398006439209
       Target Frame: <Fixed Frame>
-      Yaw: 1.955392599105835
+      Value: Orbit (rviz)
+      Yaw: 0.785398006439209
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 773
+  Height: 1733
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000024300000267fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000267000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000120020002d00200053006c00690064006500720000000000ffffffff0000000000000000fb00000038005400650073007300650072006100630074005400720061006a006500630074006f007200790020002d00200053006c00690064006500720000000000ffffffff0000004100ffffff000000010000010000000267fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d00000267000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000005a00000003efc0100000002fb0000000800540069006d00650100000000000005a0000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000002510000026700000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001650000065afc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000007300fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c00610079007301000000490000065a000000fb00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f0000065afc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007301000000490000065a000000c900fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000006270000065a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
-    collapsed: false
-  TesseractTrajectory - Slider:
-    collapsed: false
-  Time:
     collapsed: false
   Tool Properties:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1440
-  X: 2074
-  Y: 98
+  Width: 2217
+  X: 342
+  Y: 195

--- a/tesseract_ros_examples/include/tesseract_ros_examples/puzzle_piece_example.h
+++ b/tesseract_ros_examples/include/tesseract_ros_examples/puzzle_piece_example.h
@@ -34,8 +34,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <rclcpp/rclcpp.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-#include <tesseract_common/types.h>
 #include <tesseract_ros_examples/example.h>
+#include <tesseract_common/types.h>
+#include <tesseract_rosutils/plotting.h>
 
 namespace tesseract_ros_examples
 {
@@ -47,6 +48,7 @@ class PuzzlePieceExample : public Example
 {
 public:
   PuzzlePieceExample(rclcpp::Node::SharedPtr node, bool plotting, bool rviz) : Example(plotting, rviz), node_(node) {}
+  ~PuzzlePieceExample();
 
   bool run() override;
 
@@ -54,6 +56,7 @@ private:
   tesseract_common::VectorIsometry3d makePuzzleToolPoses();
 
   rclcpp::Node::SharedPtr node_;
+  tesseract_rosutils::ROSPlottingPtr plotter_;
 };
 
 }  // namespace tesseract_ros_examples

--- a/tesseract_ros_examples/launch/puzzle_piece_example.launch
+++ b/tesseract_ros_examples/launch/puzzle_piece_example.launch
@@ -25,21 +25,26 @@
     <node pkg="tf" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 world base_link 100" />
     -->
 
+    <!--
     <node pkg="tesseract_ros_examples" exec="puzzle_piece_example_node" output="screen">
       <param name="plotting" type="bool" value="$(var plotting)"/>
       <param name="rviz" type="bool" value="$(var rviz)"/>
       <param name="robot_description" value="$(var robot_description)" type="str"/>
       <param name="robot_description_semantic" value="$(var robot_description_semantic)" type="str"/>
+    -->
       <!--
       <param from="$(find-pkg-share tesseract_ros_examples)/config/joint_limits.yaml"/>
       <param from="$(find-pkg-share tesseract_ros_examples)/config/kinematics.yaml"/>
       -->
+      <!--
     </node>
+      -->
 
     <!-- Launch visualization -->
     <node pkg="rviz2" exec="rviz2"
-        args=""> <!---d $(find-pkg-share tesseract_ros_examples)/config/examples.rviz">-->
+        args="-d $(find-pkg-share tesseract_ros_examples)/config/examples.rviz">
       <param name="robot_description" value="$(var robot_description)" type="str"/>
+      <param name="robot_description_semantic" value="$(var robot_description_semantic)" type="str"/>
     </node>
   <!--
   </group>

--- a/tesseract_ros_examples/launch/puzzle_piece_example.launch
+++ b/tesseract_ros_examples/launch/puzzle_piece_example.launch
@@ -3,7 +3,7 @@
   <!-- By default we do not overwrite the URDF. Change the following to true to change the default behavior -->
   <!-- The name of the parameter under which the URDF is loaded -->
   <arg name="plotting" default="false"/>
-  <arg name="rviz" default="false"/>
+  <arg name="rviz" default="true"/>
   <arg name="testing" default="false"/>
 
   <!-- Load universal robot description format (URDF) -->
@@ -14,6 +14,9 @@
   <let name="robot_description_semantic"
        value="$(command 'cat $(find-pkg-share tesseract_ros_examples)/config/puzzle_piece_workcell.srdf')" />
 
+  <node pkg="robot_state_publisher" exec="robot_state_publisher" name="robot_state_publisher">
+      <param name="robot_description" value="$(var robot_description)" />
+  </node>
   <!--
   <group unless="$(arg testing)">
   -->
@@ -22,7 +25,7 @@
     <node pkg="tf" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 world base_link 100" />
     -->
 
-    <node pkg="tesseract_ros_examples" exec="puzzle_piece_example_node" name="tesseract_ros_examples_puzzle_piece_example_node" output="screen">
+    <node pkg="tesseract_ros_examples" exec="puzzle_piece_example_node" output="screen">
       <param name="plotting" type="bool" value="$(var plotting)"/>
       <param name="rviz" type="bool" value="$(var rviz)"/>
       <param name="robot_description" value="$(var robot_description)" type="str"/>
@@ -34,10 +37,10 @@
     </node>
 
     <!-- Launch visualization -->
-    <!--
-    <node pkg="rviz" exec="rviz" name="tesseract_ros_examples_puzzle_piece_example_rviz"
-        args="-d $(find tesseract_ros_examples)/config/examples.rviz" />
-    -->
+    <node pkg="rviz2" exec="rviz2"
+        args=""> <!---d $(find-pkg-share tesseract_ros_examples)/config/examples.rviz">-->
+      <param name="robot_description" value="$(var robot_description)" type="str"/>
+    </node>
   <!--
   </group>
   -->

--- a/tesseract_ros_examples/launch/puzzle_piece_example.launch
+++ b/tesseract_ros_examples/launch/puzzle_piece_example.launch
@@ -25,29 +25,31 @@
     <node pkg="tf" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 world base_link 100" />
     -->
 
-    <!--
     <node pkg="tesseract_ros_examples" exec="puzzle_piece_example_node" output="screen">
       <param name="plotting" type="bool" value="$(var plotting)"/>
       <param name="rviz" type="bool" value="$(var rviz)"/>
       <param name="robot_description" value="$(var robot_description)" type="str"/>
       <param name="robot_description_semantic" value="$(var robot_description_semantic)" type="str"/>
-    -->
       <!--
       <param from="$(find-pkg-share tesseract_ros_examples)/config/joint_limits.yaml"/>
       <param from="$(find-pkg-share tesseract_ros_examples)/config/kinematics.yaml"/>
       -->
-      <!--
     </node>
-      -->
 
     <!-- Launch visualization -->
     <node pkg="rviz2" exec="rviz2"
-        args="-d $(find-pkg-share tesseract_ros_examples)/config/examples.rviz">
+      args="-d $(find-pkg-share tesseract_ros_examples)/config/examples.rviz"
+      output="screen">
       <param name="robot_description" value="$(var robot_description)" type="str"/>
       <param name="robot_description_semantic" value="$(var robot_description_semantic)" type="str"/>
     </node>
   <!--
   </group>
   -->
+
+  <!-- Robot control -->
+  <node pkg="joint_state_publisher_gui" exec="joint_state_publisher_gui">
+    <param name="robot_description" value="$(var robot_description)"/>
+  </node>
 
 </launch>

--- a/tesseract_ros_examples/src/puzzle_piece_example.cpp
+++ b/tesseract_ros_examples/src/puzzle_piece_example.cpp
@@ -150,9 +150,9 @@ bool PuzzlePieceExample::run()
     monitor_->startPublishingEnvironment();
 
   // Create plotting tool
+  plotter_ = std::make_shared<tesseract_rosutils::ROSPlotting>(monitor_->getSceneGraph()->getRoot());
   if (plotting_)
   {
-    plotter_ = std::make_shared<tesseract_rosutils::ROSPlotting>(monitor_->getSceneGraph()->getRoot());
     plotter_->waitForConnection();
   }
 
@@ -261,19 +261,19 @@ bool PuzzlePieceExample::run()
     plotter_->waitForInput();
 
   // Solve process plan
-  //ProcessPlanningFuture response = planning_server.run(request);
-  //planning_server.waitForAll();
+  ProcessPlanningFuture response = planning_server.run(request);
+  planning_server.waitForAll();
   RCLCPP_INFO(node_->get_logger(), "Final trajectory is collision free");
 
   // Plot Process Trajectory
   if (rviz_ && plotter_ != nullptr && plotter_->isConnected())
   {
     RCLCPP_INFO(node_->get_logger(), "Sending trajectory for visualization");
-    plotter_->waitForInput();
-    //const auto& ci = response.results->as<CompositeInstruction>();
-    //tesseract_common::JointTrajectory trajectory = toJointTrajectory(ci);
+    //plotter_->waitForInput();
+    const auto& ci = response.results->as<CompositeInstruction>();
+    tesseract_common::JointTrajectory trajectory = toJointTrajectory(ci);
     auto state_solver = env_->getStateSolver();
-    //plotter_->plotTrajectory(trajectory, *state_solver);
+    plotter_->plotTrajectory(trajectory, *state_solver);
   }
 
   return true;

--- a/tesseract_ros_examples/src/puzzle_piece_example.cpp
+++ b/tesseract_ros_examples/src/puzzle_piece_example.cpp
@@ -31,7 +31,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_ros_examples/puzzle_piece_example.h>
 #include <tesseract_environment/utils.h>
-#include <tesseract_rosutils/plotting.h>
 #include <tesseract_rosutils/utils.h>
 #include <tesseract_command_language/command_language.h>
 #include <tesseract_command_language/types.h>
@@ -52,7 +51,6 @@ using namespace trajopt;
 using namespace tesseract_environment;
 using namespace tesseract_scene_graph;
 using namespace tesseract_collision;
-using namespace tesseract_rosutils;
 using namespace tesseract_visualization;
 using namespace tesseract_planning;
 
@@ -127,6 +125,11 @@ tesseract_common::VectorIsometry3d PuzzlePieceExample::makePuzzleToolPoses()
   return path;
 }
 
+PuzzlePieceExample::~PuzzlePieceExample()
+{
+  RCLCPP_WARN(node_->get_logger(), "Destroying example");
+}
+
 bool PuzzlePieceExample::run()
 {
   using tesseract_planning_server::ROSProcessEnvironmentCache;
@@ -147,9 +150,13 @@ bool PuzzlePieceExample::run()
     monitor_->startPublishingEnvironment();
 
   // Create plotting tool
-  ROSPlottingPtr plotter = std::make_shared<ROSPlotting>(monitor_->getSceneGraph()->getRoot());
-  if (rviz_)
-    plotter->waitForConnection();
+  if (plotting_)
+  {
+    plotter_ = std::make_shared<tesseract_rosutils::ROSPlotting>(monitor_->getSceneGraph()->getRoot());
+    plotter_->waitForConnection();
+  }
+
+  std::this_thread::sleep_for(std::chrono::seconds{5});
 
   // Set the robot initial state
   std::vector<std::string> joint_names;
@@ -250,24 +257,25 @@ bool PuzzlePieceExample::run()
   request.instructions.print("Program: ");
   request.seed.print("Seed: ");
 
-  if (rviz_)
-    plotter->waitForInput();
+  if (plotting_)
+    plotter_->waitForInput();
 
   // Solve process plan
-  ProcessPlanningFuture response = planning_server.run(request);
-  planning_server.waitForAll();
+  //ProcessPlanningFuture response = planning_server.run(request);
+  //planning_server.waitForAll();
+  RCLCPP_INFO(node_->get_logger(), "Final trajectory is collision free");
 
   // Plot Process Trajectory
-  if (rviz_ && plotter != nullptr && plotter->isConnected())
+  if (rviz_ && plotter_ != nullptr && plotter_->isConnected())
   {
-    plotter->waitForInput();
-    const auto& ci = response.results->as<CompositeInstruction>();
-    tesseract_common::JointTrajectory trajectory = toJointTrajectory(ci);
+    RCLCPP_INFO(node_->get_logger(), "Sending trajectory for visualization");
+    plotter_->waitForInput();
+    //const auto& ci = response.results->as<CompositeInstruction>();
+    //tesseract_common::JointTrajectory trajectory = toJointTrajectory(ci);
     auto state_solver = env_->getStateSolver();
-    plotter->plotTrajectory(trajectory, *state_solver);
+    //plotter_->plotTrajectory(trajectory, *state_solver);
   }
 
-  RCLCPP_INFO(node_->get_logger(), "Final trajectory is collision free");
   return true;
 }
 }  // namespace tesseract_ros_examples

--- a/tesseract_ros_examples/src/puzzle_piece_example_node.cpp
+++ b/tesseract_ros_examples/src/puzzle_piece_example_node.cpp
@@ -24,6 +24,8 @@
  * limitations under the License.
  */
 
+#include <thread>
+
 #include <tesseract_ros_examples/puzzle_piece_example.h>
 
 int main(int argc, char** argv)
@@ -36,7 +38,19 @@ int main(int argc, char** argv)
   bool rviz = node->declare_parameter("rviz", true);
 
   tesseract_ros_examples::PuzzlePieceExample example(node, plotting, rviz);
+
+  std::thread spinner{
+    [node]()
+    {
+      rclcpp::spin(node);
+    }
+  };
+
   example.run();
+
+  RCLCPP_INFO(node->get_logger(), "Example completed, waiting for ROS shutdown...");
+  spinner.join();
+  RCLCPP_INFO(node->get_logger(), "Shutdown!");
 
   return 0;
 }

--- a/tesseract_rviz/CMakeLists.txt
+++ b/tesseract_rviz/CMakeLists.txt
@@ -250,9 +250,11 @@ install(TARGETS ${PROJECT_NAME}_render_tools
     EXPORT ${PACKAGE_NAME}-targets
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
-    RUNTIME DESTINATION lib/${PROJECT_NAME}
+    RUNTIME DESTINATION bin
     INCLUDES DESTINATION include
 )
+
+install(TARGETS ${PROJECT_NAME}_test DESTINATION lib/${PROJECT_NAME})
 
 # Mark cpp header files for installation
 install(DIRECTORY include/
@@ -260,6 +262,9 @@ install(DIRECTORY include/
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE
 )
+
+# Resource files for visualizations
+install(DIRECTORY ogre_media DESTINATION share/${PROJECT_NAME})
 
 # Mark plugin XML files for installation
 install(FILES tesseract_rviz_state_plugin_description.xml

--- a/tesseract_rviz/CMakeLists.txt
+++ b/tesseract_rviz/CMakeLists.txt
@@ -1,34 +1,40 @@
 cmake_minimum_required(VERSION 3.5.0)
-project(tesseract_rviz)
+project(tesseract_rviz VERSION 0.1.0)
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  message_generation
-  tesseract_msgs
-  tesseract_rosutils
-  tesseract_monitoring
-  rviz
-  pluginlib
-  interactive_markers
-)
+add_compile_options(-std=c++11 -Wall -Wextra)
 
-## System dependencies are found with CMake's conventions
+find_package(ament_cmake REQUIRED)
+find_package(interactive_markers REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rviz_common REQUIRED)
+find_package(rviz_rendering REQUIRED)
+find_package(rviz_ogre_vendor REQUIRED)
+
+find_package(tesseract REQUIRED)
+find_package(tesseract_msgs REQUIRED)
+find_package(tesseract_rosutils REQUIRED)
+
 find_package(Boost REQUIRED thread date_time system filesystem)
-find_package(tesseract_environment REQUIRED)
-find_package(tesseract_motion_planners REQUIRED)
-find_package(tesseract_common REQUIRED)
-find_package(tesseract_visualization REQUIRED)
+find_package(console_bridge REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(ros_industrial_cmake_boilerplate REQUIRED)
+
+list(FIND CMAKE_CXX_COMPILE_FEATURES cxx_std_11 CXX_FEATURE_FOUND)
 
 # Ogre
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(OGRE OGRE)
-link_directories(${OGRE_LIBRARY_DIRS} )
+#find_package(PkgConfig REQUIRED)
+#pkg_check_modules(OGRE OGRE)
+#link_directories(${OGRE_LIBRARY_DIRS} )
+
+# TODO: Find out if this still exists
+find_package(Qt5 REQUIRED COMPONENTS Widgets)
+set(rviz2_QT_VERSION 5)
+message(WARNING QT5_Found: ${Qt5_FOUND})
+
 
 # Qt Stuff
-if(rviz_QT_VERSION VERSION_LESS "5")
-  find_package(Qt4 ${rviz_QT_VERSION} REQUIRED QtCore QtGui)
+if(rviz2_QT_VERSION VERSION_LESS "5")
+  find_package(Qt4 ${rviz2_QT_VERSION} REQUIRED QtCore QtGui)
   include(${QT_USE_FILE})
   macro(qt_wrap_ui)
     qt4_wrap_ui(${ARGN})
@@ -37,7 +43,7 @@ if(rviz_QT_VERSION VERSION_LESS "5")
     qt4_wrap_cpp(${ARGN})
   endmacro()
 else()
-  find_package(Qt5 ${rviz_QT_VERSION} REQUIRED Core Widgets)
+  find_package(Qt5 ${rviz2_QT_VERSION} REQUIRED Core Widgets)
   set(QT_LIBRARIES Qt5::Widgets)
   macro(qt_wrap_ui)
     qt5_wrap_ui(${ARGN})
@@ -49,79 +55,44 @@ endif()
 
 add_definitions(-DQT_NO_KEYWORDS)
 
-catkin_package(
-  INCLUDE_DIRS
-    include
-    ${Boost_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIRS}
-    ${QT_INCLUDE_DIR}
-    ${OGRE_INCLUDE_DIRS}
-  LIBRARIES
-    ${PROJECT_NAME}_render_tools
-    ${PROJECT_NAME}_state_plugin_core
-  CATKIN_DEPENDS
-    roscpp
-    message_generation
-    tesseract_msgs
-    tesseract_rosutils
-    tesseract_monitoring
-    rviz
-    pluginlib
-    interactive_markers
-  DEPENDS
-    Boost
-    OGRE
-    QT
-    tesseract_environment
-    tesseract_common
-    tesseract_visualization
-    tesseract_motion_planners
-)
-
-# Load variable for clang tidy args, compiler options and cxx version
-tesseract_variables()
-
 include_directories(
   include
-  ${catkin_INCLUDE_DIRS}
   SYSTEM ${Boost_INCLUDE_DIRS}
   SYSTEM ${EIGEN3_INCLUDE_DIRS}
   SYSTEM ${QT_INCLUDE_DIR}
-  SYSTEM ${OGRE_INCLUDE_DIRS}
+#  SYSTEM ${OGRE_INCLUDE_DIRS}
 )
 
 # Rviz Render Tools
 qt_wrap_cpp(${PROJECT_NAME}_render_tools_cpp_MOCS
   include/tesseract_rviz/render_tools/trajectory_panel.h
   include/tesseract_rviz/render_tools/visualization_widget.h
-  include/tesseract_rviz/render_tools/visualize_trajectory_widget.h
   include/tesseract_rviz/render_tools/link_widget.h
   include/tesseract_rviz/render_tools/joint_widget.h
   include/tesseract_rviz/render_tools/joint_state_monitor_widget.h
   include/tesseract_rviz/render_tools/environment_widget.h
   include/tesseract_rviz/render_tools/trajectory_monitor_widget.h
-  include/tesseract_rviz/render_tools/manipulation_widget.h
+#  include/tesseract_rviz/render_tools/manipulation_widget.h
   include/tesseract_rviz/interactive_marker/integer_action.h
-  include/tesseract_rviz/interactive_marker/interactive_marker.h
+#  include/tesseract_rviz/interactive_marker/interactive_marker.h
   include/tesseract_rviz/property/button_property.h
   )
 
 add_library(${PROJECT_NAME}_render_tools SHARED
   src/render_tools/visualization_widget.cpp
-  src/render_tools/visualize_trajectory_widget.cpp
   src/render_tools/joint_widget.cpp
   src/render_tools/link_widget.cpp
   src/render_tools/trajectory_panel.cpp
   src/render_tools/joint_state_monitor_widget.cpp
   src/render_tools/environment_widget.cpp
   src/render_tools/trajectory_monitor_widget.cpp
-  src/render_tools/manipulation_widget.cpp
+#  src/render_tools/manipulation_widget.cpp
   src/interactive_marker/integer_action.cpp
-  src/interactive_marker/interactive_marker.cpp
-  src/interactive_marker/interactive_marker_control.cpp
+#  src/interactive_marker/interactive_marker.cpp
+#  src/interactive_marker/interactive_marker_control.cpp
   src/markers/marker_base.cpp
   src/markers/marker_selection_handler.cpp
-  src/markers/utils.cpp
+#  src/markers/utils.cpp
   src/markers/arrow_marker.cpp
   src/markers/sphere_marker.cpp
   src/markers/cube_marker.cpp
@@ -131,245 +102,231 @@ add_library(${PROJECT_NAME}_render_tools SHARED
   src/property/button_property.cpp
   ${${PROJECT_NAME}_render_tools_cpp_MOCS}
 )
-
 target_link_libraries(${PROJECT_NAME}_render_tools PUBLIC
-  tesseract::tesseract_environment
-  tesseract::tesseract_motion_planners_core
-  tesseract::tesseract_visualization
-  ${catkin_LIBRARIES}
-  ${OGRE_LIBRARIES}
-  ${QT_LIBRARIES}
-  ${Boost_LIBRARIES}
+  tesseract::tesseract
+  rviz_ogre_vendor::OgreMain
+  rviz_ogre_vendor::OgreOverlay
+  Qt5::Widgets
+  rviz_common::rviz_common
+  rviz_rendering::rviz_rendering)
+ament_target_dependencies(${PROJECT_NAME}_render_tools PUBLIC
+  tesseract_msgs
+  tesseract_rosutils
+#  ${OGRE_LIBRARIES}
 )
 
-target_compile_options(${PROJECT_NAME}_render_tools PUBLIC ${TESSERACT_COMPILE_OPTIONS})
-target_cxx_version(${PROJECT_NAME}_render_tools PUBLIC VERSION 17)
+target_compile_options(${PROJECT_NAME}_render_tools PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
+if(CXX_FEATURE_FOUND EQUAL "-1")
+    target_compile_options(${PROJECT_NAME}_render_tools PUBLIC -std=c++11)
+else()
+    target_compile_features(${PROJECT_NAME}_render_tools PUBLIC cxx_std_11)
+endif()
 target_include_directories(${PROJECT_NAME}_render_tools PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_render_tools SYSTEM PUBLIC
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-    ${QT_INCLUDE_DIR}
-    ${OGRE_INCLUDE_DIRS}
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+#    ${OGRE_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS})
-target_compile_definitions(${PROJECT_NAME}_render_tools PUBLIC $ENV{ROS_DISTRO}_BUILD)
 
 #add_library(${PROJECT_NAME}_scene_plugin_core
 #  src/tesseract_scene_plugin/tesseract_scene_display.cpp
 #  include/tesseract_rviz/tesseract_scene_plugin/tesseract_scene_display.h)
-#target_link_libraries(${PROJECT_NAME}_scene_plugin_core ${PROJECT_NAME}_render_tools ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+#ament_add_dependencies(${PROJECT_NAME}_scene_plugin_core ${PROJECT_NAME}_render_tools ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
 
 #add_library(${PROJECT_NAME}_scene_plugin src/tesseract_scene_plugin/plugin_init.cpp)
-#target_link_libraries(${PROJECT_NAME}_scene_plugin ${PROJECT_NAME}_scene_plugin_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+#ament_add_dependencies(${PROJECT_NAME}_scene_plugin ${PROJECT_NAME}_scene_plugin_core ${Boost_LIBRARIES})
 
-# Trajectory State Disply
-qt_wrap_cpp(${PROJECT_NAME}_state_plugin_core_cpp_MOCS include/tesseract_rviz/environment_state_plugin/environment_state_display.h)
+# Trajectory State Display
+qt_wrap_cpp(${PROJECT_NAME}_state_plugin_core_cpp_MOCS include/tesseract_rviz/tesseract_state_plugin/tesseract_state_display.h)
 
-add_library(${PROJECT_NAME}_state_plugin_core SHARED src/environment_state_plugin/environment_state_display.cpp ${${PROJECT_NAME}_state_plugin_core_cpp_MOCS})
-target_link_libraries(${PROJECT_NAME}_state_plugin_core PUBLIC
-    ${PROJECT_NAME}_render_tools
-    ${catkin_LIBRARIES}
-    ${OGRE_LIBRARIES}
-    ${QT_LIBRARIES}
-    ${Boost_LIBRARIES})
-target_compile_options(${PROJECT_NAME}_state_plugin_core PUBLIC ${TESSERACT_COMPILE_OPTIONS})
-target_cxx_version(${PROJECT_NAME}_state_plugin_core PUBLIC VERSION 17)
+add_library(${PROJECT_NAME}_state_plugin_core SHARED src/tesseract_state_plugin/tesseract_state_display.cpp ${${PROJECT_NAME}_state_plugin_core_cpp_MOCS})
+target_link_libraries(${PROJECT_NAME}_state_plugin_core PUBLIC ${PROJECT_NAME}_render_tools)
+target_compile_options(${PROJECT_NAME}_state_plugin_core PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
+if(CXX_FEATURE_FOUND EQUAL "-1")
+    target_compile_options(${PROJECT_NAME}_state_plugin_core PUBLIC -std=c++14)
+else()
+    target_compile_features(${PROJECT_NAME}_state_plugin_core PUBLIC cxx_std_14)
+endif()
 target_include_directories(${PROJECT_NAME}_state_plugin_core PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_state_plugin_core SYSTEM PUBLIC
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-    ${QT_INCLUDE_DIR}
-    ${OGRE_INCLUDE_DIRS}
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+#    ${OGRE_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME}_state_plugin SHARED src/environment_state_plugin/plugin_init.cpp)
-target_link_libraries(${PROJECT_NAME}_state_plugin PRIVATE ${PROJECT_NAME}_state_plugin_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-target_compile_options(${PROJECT_NAME}_state_plugin PUBLIC ${TESSERACT_COMPILE_OPTIONS})
-target_cxx_version(${PROJECT_NAME}_state_plugin PUBLIC VERSION 17)
+add_library(${PROJECT_NAME}_state_plugin SHARED src/tesseract_state_plugin/plugin_init.cpp)
+target_link_libraries(${PROJECT_NAME}_state_plugin PRIVATE ${PROJECT_NAME}_state_plugin_core)
+target_compile_options(${PROJECT_NAME}_state_plugin PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
+if(CXX_FEATURE_FOUND EQUAL "-1")
+    target_compile_options(${PROJECT_NAME}_state_plugin PUBLIC -std=c++14)
+else()
+    target_compile_features(${PROJECT_NAME}_state_plugin PUBLIC cxx_std_14)
+endif()
 target_include_directories(${PROJECT_NAME}_state_plugin PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_state_plugin SYSTEM PRIVATE
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS})
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
 
 ## Trajectory Display
 qt_wrap_cpp(${PROJECT_NAME}_trajectory_plugin_core_cpp_MOCS include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h)
 
 add_library(${PROJECT_NAME}_trajectory_plugin_core SHARED src/tesseract_trajectory_plugin/tesseract_trajectory_display.cpp ${${PROJECT_NAME}_trajectory_plugin_core_cpp_MOCS})
 target_link_libraries(${PROJECT_NAME}_trajectory_plugin_core PUBLIC
-    ${PROJECT_NAME}_render_tools
-    ${PROJECT_NAME}_state_plugin_core
-    tesseract::tesseract_environment
-    ${catkin_LIBRARIES}
-    ${OGRE_LIBRARIES}
-    ${QT_LIBRARIES}
-    ${Boost_LIBRARIES})
-target_compile_options(${PROJECT_NAME}_trajectory_plugin_core PUBLIC ${TESSERACT_COMPILE_OPTIONS})
-target_cxx_version(${PROJECT_NAME}_trajectory_plugin_core PUBLIC VERSION 17)
+  ${PROJECT_NAME}_render_tools
+  ${PROJECT_NAME}_state_plugin_core
+  tesseract::tesseract
+#  ${OGRE_LIBRARIES}
+  )
+target_compile_options(${PROJECT_NAME}_trajectory_plugin_core PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
+if(CXX_FEATURE_FOUND EQUAL "-1")
+    target_compile_options(${PROJECT_NAME}_trajectory_plugin_core PUBLIC -std=c++11)
+else()
+    target_compile_features(${PROJECT_NAME}_trajectory_plugin_core PUBLIC cxx_std_11)
+endif()
 target_include_directories(${PROJECT_NAME}_trajectory_plugin_core PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_trajectory_plugin_core SYSTEM PUBLIC
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-    ${QT_INCLUDE_DIR}
-    ${OGRE_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIRS})
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+#    ${OGRE_INCLUDE_DIRS}
+#    ${EIGEN3_INCLUDE_DIRS}
+    )
 
 add_library(${PROJECT_NAME}_trajectory_plugin SHARED src/tesseract_trajectory_plugin/plugin_init.cpp)
 target_link_libraries(${PROJECT_NAME}_trajectory_plugin PRIVATE
     ${PROJECT_NAME}_trajectory_plugin_core
-    tesseract::tesseract_environment
-    ${catkin_LIBRARIES}
-    ${Boost_LIBRARIES})
-target_compile_options(${PROJECT_NAME}_trajectory_plugin PUBLIC ${TESSERACT_COMPILE_OPTIONS})
-target_cxx_version(${PROJECT_NAME}_trajectory_plugin PUBLIC VERSION 17)
+    tesseract::tesseract
+    )
+target_compile_options(${PROJECT_NAME}_trajectory_plugin PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
+if(CXX_FEATURE_FOUND EQUAL "-1")
+    target_compile_options(${PROJECT_NAME}_trajectory_plugin PUBLIC -std=c++14)
+else()
+    target_compile_features(${PROJECT_NAME}_trajectory_plugin PUBLIC cxx_std_14)
+endif()
 target_include_directories(${PROJECT_NAME}_trajectory_plugin PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_trajectory_plugin SYSTEM PRIVATE
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIRS})
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+#    ${EIGEN3_INCLUDE_DIRS}
+    )
 
-## Planning Response Archive Display
-qt_wrap_cpp(${PROJECT_NAME}_planning_response_archive_plugin_core_cpp_MOCS include/tesseract_rviz/planning_response_archive_plugin/planning_response_archive_display.h)
+### Manipulation Display
+#qt_wrap_cpp(${PROJECT_NAME}_manipulation_plugin_core_cpp_MOCS include/tesseract_rviz/tesseract_manipulation_plugin/tesseract_manipulation_display.h)
 
-add_library(${PROJECT_NAME}_planning_response_archive_plugin_core SHARED src/planning_response_archive_plugin/planning_response_archive_display.cpp ${${PROJECT_NAME}_planning_response_archive_plugin_core_cpp_MOCS})
-target_link_libraries(${PROJECT_NAME}_planning_response_archive_plugin_core PUBLIC
-    ${PROJECT_NAME}_render_tools
-    ${PROJECT_NAME}_state_plugin_core
-    tesseract::tesseract_environment
-    ${catkin_LIBRARIES}
-    ${OGRE_LIBRARIES}
-    ${QT_LIBRARIES}
-    ${Boost_LIBRARIES})
-target_compile_options(${PROJECT_NAME}_planning_response_archive_plugin_core PUBLIC ${TESSERACT_COMPILE_OPTIONS})
-target_cxx_version(${PROJECT_NAME}_planning_response_archive_plugin_core PUBLIC VERSION 17)
-target_include_directories(${PROJECT_NAME}_planning_response_archive_plugin_core PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_planning_response_archive_plugin_core SYSTEM PUBLIC
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-    ${QT_INCLUDE_DIR}
-    ${OGRE_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIRS})
+#add_library(${PROJECT_NAME}_manipulation_plugin_core SHARED src/tesseract_manipulation_plugin/tesseract_manipulation_display.cpp ${${PROJECT_NAME}_manipulation_plugin_core_cpp_MOCS})
+#ament_add_dependencies(${PROJECT_NAME}_manipulation_plugin_core PUBLIC
+#    ${PROJECT_NAME}_render_tools
+#    tesseract::tesseract
+#    ${OGRE_LIBRARIES}
+#    ${QT_LIBRARIES}
+#    ${Boost_LIBRARIES}
+#    ${EIGEN3_INCLUDE_DIRS})
+#target_compile_options(${PROJECT_NAME}_manipulation_plugin_core PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
+#if(CXX_FEATURE_FOUND EQUAL "-1")
+#    target_compile_options(${PROJECT_NAME}_manipulation_plugin_core PUBLIC -std=c++11)
+#else()
+#    target_compile_features(${PROJECT_NAME}_manipulation_plugin_core PUBLIC cxx_std_11)
+#endif()
+#target_include_directories(${PROJECT_NAME}_manipulation_plugin_core PUBLIC
+#    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+#    "$<INSTALL_INTERFACE:include>")
+#target_include_directories(${PROJECT_NAME}_manipulation_plugin_core SYSTEM PUBLIC
+#  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+#  "$<INSTALL_INTERFACE:include>"
+#    ${Boost_INCLUDE_DIRS}
+#    ${QT_INCLUDE_DIR}
+#    ${OGRE_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME}_planning_response_archive_plugin SHARED src/planning_response_archive_plugin/plugin_init.cpp)
-target_link_libraries(${PROJECT_NAME}_planning_response_archive_plugin PRIVATE
-    ${PROJECT_NAME}_planning_response_archive_plugin_core
-    tesseract::tesseract_environment
-    ${catkin_LIBRARIES}
-    ${Boost_LIBRARIES})
-target_compile_options(${PROJECT_NAME}_planning_response_archive_plugin PUBLIC ${TESSERACT_COMPILE_OPTIONS})
-target_cxx_version(${PROJECT_NAME}_planning_response_archive_plugin PUBLIC VERSION 17)
-target_include_directories(${PROJECT_NAME}_planning_response_archive_plugin PRIVATE
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_planning_response_archive_plugin SYSTEM PRIVATE
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIRS})
-
-
-## Manipulation Display
-qt_wrap_cpp(${PROJECT_NAME}_manipulation_plugin_core_cpp_MOCS include/tesseract_rviz/tesseract_manipulation_plugin/tesseract_manipulation_display.h)
-
-add_library(${PROJECT_NAME}_manipulation_plugin_core SHARED src/tesseract_manipulation_plugin/tesseract_manipulation_display.cpp ${${PROJECT_NAME}_manipulation_plugin_core_cpp_MOCS})
-target_link_libraries(${PROJECT_NAME}_manipulation_plugin_core PUBLIC
-    ${PROJECT_NAME}_render_tools
-    tesseract::tesseract_environment
-    ${catkin_LIBRARIES}
-    ${OGRE_LIBRARIES}
-    ${QT_LIBRARIES}
-    ${Boost_LIBRARIES}
-    ${EIGEN3_INCLUDE_DIRS})
-target_compile_options(${PROJECT_NAME}_manipulation_plugin_core PUBLIC ${TESSERACT_COMPILE_OPTIONS})
-target_cxx_version(${PROJECT_NAME}_manipulation_plugin_core PUBLIC VERSION 17)
-target_include_directories(${PROJECT_NAME}_manipulation_plugin_core PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_manipulation_plugin_core SYSTEM PUBLIC
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-    ${QT_INCLUDE_DIR}
-    ${OGRE_INCLUDE_DIRS})
-
-add_library(${PROJECT_NAME}_manipulation_plugin SHARED src/tesseract_manipulation_plugin/plugin_init.cpp)
-target_link_libraries(${PROJECT_NAME}_manipulation_plugin PRIVATE
-    ${PROJECT_NAME}_manipulation_plugin_core
-    tesseract::tesseract_environment
-    ${catkin_LIBRARIES}
-    ${Boost_LIBRARIES})
-target_compile_options(${PROJECT_NAME}_manipulation_plugin PUBLIC ${TESSERACT_COMPILE_OPTIONS})
-target_cxx_version(${PROJECT_NAME}_manipulation_plugin PUBLIC VERSION 17)
-target_include_directories(${PROJECT_NAME}_manipulation_plugin PRIVATE
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_manipulation_plugin SYSTEM PRIVATE
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIRS})
+#add_library(${PROJECT_NAME}_manipulation_plugin SHARED src/tesseract_manipulation_plugin/plugin_init.cpp)
+#ament_add_dependencies(${PROJECT_NAME}_manipulation_plugin PRIVATE
+#    ${PROJECT_NAME}_manipulation_plugin_core
+#    tesseract::tesseract
+#    ${Boost_LIBRARIES})
+#target_compile_options(${PROJECT_NAME}_manipulation_plugin PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
+#if(CXX_FEATURE_FOUND EQUAL "-1")
+#    target_compile_options(${PROJECT_NAME}_manipulation_plugin PUBLIC -std=c++11)
+#else()
+#    target_compile_features(${PROJECT_NAME}_manipulation_plugin PUBLIC cxx_std_11)
+#endif()
+#target_include_directories(${PROJECT_NAME}_manipulation_plugin PRIVATE
+#    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+#    "$<INSTALL_INTERFACE:include>")
+#target_include_directories(${PROJECT_NAME}_manipulation_plugin SYSTEM PRIVATE
+#  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+#  "$<INSTALL_INTERFACE:include>"
+#    ${Boost_INCLUDE_DIRS}
+#    ${EIGEN3_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME}_test src/test.cpp)
-target_link_libraries(${PROJECT_NAME}_test PRIVATE ${PROJECT_NAME}_trajectory_plugin_core ${catkin_LIBRARIES})
-target_compile_options(${PROJECT_NAME}_test PUBLIC ${TESSERACT_COMPILE_OPTIONS})
-target_cxx_version(${PROJECT_NAME}_test PUBLIC VERSION 17)
+target_link_libraries(${PROJECT_NAME}_test PRIVATE ${PROJECT_NAME}_trajectory_plugin_core)
+target_compile_options(${PROJECT_NAME}_test PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
+if(CXX_FEATURE_FOUND EQUAL "-1")
+    target_compile_options(${PROJECT_NAME}_test PUBLIC -std=c++14)
+else()
+    target_compile_features(${PROJECT_NAME}_test PUBLIC cxx_std_14)
+endif()
 target_include_directories(${PROJECT_NAME}_test PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_test SYSTEM PRIVATE
-    ${catkin_INCLUDE_DIRS})
-
-# Files generated by MOC, RCC, and UIC may produce clang-tidy warnings.
-# We generate a dummy .clang-tidy file in the binary directory that disables
-# all clang-tidy checks except one that will never match.  This one check is
-# necessary; clang-tidy reports an error when no checks are enabled.
-# Since the Qt code generators will generate source files in the binary tree,
-# clang-tidy will load the configuration from this dummy file when the sources
-# are built.
-#file(WRITE "${tesseract_rviz_BINARY_DIR}/.clang-tidy" "
-#---
-#Checks: '-*,llvm-twine-local'
-#...
-#")
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
 
 
 # Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME}_render_tools
+install(TARGETS
+    ${PROJECT_NAME}_render_tools
     ${PROJECT_NAME}_state_plugin_core
     ${PROJECT_NAME}_state_plugin
     ${PROJECT_NAME}_trajectory_plugin_core
     ${PROJECT_NAME}_trajectory_plugin
-    ${PROJECT_NAME}_planning_response_archive_plugin_core
-    ${PROJECT_NAME}_planning_response_archive_plugin
-    ${PROJECT_NAME}_manipulation_plugin_core
-    ${PROJECT_NAME}_manipulation_plugin
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+#    ${PROJECT_NAME}_manipulation_plugin_core
+#    ${PROJECT_NAME}_manipulation_plugin
+    EXPORT ${PACKAGE_NAME}-targets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+    INCLUDES DESTINATION include
 )
 
 # Mark cpp header files for installation
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+install(DIRECTORY include/
+  DESTINATION include
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE
 )
 
 # Mark plugin XML files for installation
-install(FILES tesseract_rviz_state_plugin_description.xml
-    tesseract_rviz_trajectory_plugin_description.xml
-    tesseract_rviz_planning_response_archive_plugin_description.xml
-    tesseract_rviz_manipulation_plugin_description.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+install(FILES tesseract_rviz_state_plugin_description.xml tesseract_rviz_trajectory_plugin_description.xml #tesseract_rviz_manipulation_plugin_description.xml
+  DESTINATION share/${PROJECT_NAME}
 )
+pluginlib_export_plugin_description_file(rviz_common tesseract_rviz_state_plugin_description.xml)
+pluginlib_export_plugin_description_file(rviz_common tesseract_rviz_trajectory_plugin_description.xml)
+#pluginlib_export_plugin_description_file(rviz_common tesseract_rviz_manipulation_plugin_description.xml)
 
-install(DIRECTORY ogre_media
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+ament_export_dependencies(
+    ament_cmake
+    interactive_markers
+    pluginlib
+    rclcpp
+    rviz_common
+    rviz_rendering
+    rviz_ogre_vendor
+    tesseract
+    tesseract_msgs
+    tesseract_rosutils
+    Boost
+    console_bridge
+    Eigen3)
+
+ament_export_interfaces(${PACKAGE_NAME}-targets)
+ament_package()

--- a/tesseract_rviz/CMakeLists.txt
+++ b/tesseract_rviz/CMakeLists.txt
@@ -1,7 +1,6 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.9)
 project(tesseract_rviz VERSION 0.1.0)
 
-add_compile_options(-std=c++11 -Wall -Wextra)
 
 find_package(ament_cmake REQUIRED)
 find_package(interactive_markers REQUIRED)
@@ -10,89 +9,65 @@ find_package(rclcpp REQUIRED)
 find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
-
-find_package(tesseract REQUIRED)
 find_package(tesseract_msgs REQUIRED)
+find_package(tesseract_monitoring REQUIRED)
 find_package(tesseract_rosutils REQUIRED)
 
-find_package(Boost REQUIRED thread date_time system filesystem)
-find_package(console_bridge REQUIRED)
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED COMPONENTS thread date_time system filesystem)
+find_package(tesseract_environment REQUIRED)
+find_package(tesseract_motion_planners REQUIRED)
+find_package(tesseract_common REQUIRED)
+find_package(tesseract_visualization REQUIRED)
 find_package(Eigen3 REQUIRED)
-
-list(FIND CMAKE_CXX_COMPILE_FEATURES cxx_std_11 CXX_FEATURE_FOUND)
+find_package(ros_industrial_cmake_boilerplate REQUIRED)
+find_package(console_bridge REQUIRED)
 
 # Ogre
 #find_package(PkgConfig REQUIRED)
 #pkg_check_modules(OGRE OGRE)
 #link_directories(${OGRE_LIBRARY_DIRS} )
 
-# TODO: Find out if this still exists
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
-set(rviz2_QT_VERSION 5)
-message(WARNING QT5_Found: ${Qt5_FOUND})
-
-
-# Qt Stuff
-if(rviz2_QT_VERSION VERSION_LESS "5")
-  find_package(Qt4 ${rviz2_QT_VERSION} REQUIRED QtCore QtGui)
-  include(${QT_USE_FILE})
-  macro(qt_wrap_ui)
-    qt4_wrap_ui(${ARGN})
-  endmacro()
-  macro(qt_wrap_cpp)
-    qt4_wrap_cpp(${ARGN})
-  endmacro()
-else()
-  find_package(Qt5 ${rviz2_QT_VERSION} REQUIRED Core Widgets)
-  set(QT_LIBRARIES Qt5::Widgets)
-  macro(qt_wrap_ui)
-    qt5_wrap_ui(${ARGN})
-  endmacro()
-  macro(qt_wrap_cpp)
-    qt5_wrap_cpp(${ARGN})
-  endmacro()
-endif()
-
+find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
 add_definitions(-DQT_NO_KEYWORDS)
+set(CMAKE_AUTOMOC ON)
 
-include_directories(
-  include
-  SYSTEM ${Boost_INCLUDE_DIRS}
-  SYSTEM ${EIGEN3_INCLUDE_DIRS}
-  SYSTEM ${QT_INCLUDE_DIR}
-#  SYSTEM ${OGRE_INCLUDE_DIRS}
-)
+# Load variable for clang tidy args, compiler options and cxx version
+tesseract_variables()
 
 # Rviz Render Tools
-qt_wrap_cpp(${PROJECT_NAME}_render_tools_cpp_MOCS
+# qt5_wrap_cpp(${PROJECT_NAME}_render_tools_cpp_MOCS
+set(render_tools_qobjects
   include/tesseract_rviz/render_tools/trajectory_panel.h
   include/tesseract_rviz/render_tools/visualization_widget.h
+  include/tesseract_rviz/render_tools/visualize_trajectory_widget.h
   include/tesseract_rviz/render_tools/link_widget.h
   include/tesseract_rviz/render_tools/joint_widget.h
   include/tesseract_rviz/render_tools/joint_state_monitor_widget.h
   include/tesseract_rviz/render_tools/environment_widget.h
-  include/tesseract_rviz/render_tools/trajectory_monitor_widget.h
-#  include/tesseract_rviz/render_tools/manipulation_widget.h
+# include/tesseract_rviz/render_tools/trajectory_monitor_widget.h
+# include/tesseract_rviz/render_tools/manipulation_widget.h
   include/tesseract_rviz/interactive_marker/integer_action.h
-#  include/tesseract_rviz/interactive_marker/interactive_marker.h
+# include/tesseract_rviz/interactive_marker/interactive_marker.h
   include/tesseract_rviz/property/button_property.h
-  )
+)
 
 add_library(${PROJECT_NAME}_render_tools SHARED
   src/render_tools/visualization_widget.cpp
+  src/render_tools/visualize_trajectory_widget.cpp
   src/render_tools/joint_widget.cpp
   src/render_tools/link_widget.cpp
   src/render_tools/trajectory_panel.cpp
   src/render_tools/joint_state_monitor_widget.cpp
   src/render_tools/environment_widget.cpp
-  src/render_tools/trajectory_monitor_widget.cpp
-#  src/render_tools/manipulation_widget.cpp
+# src/render_tools/trajectory_monitor_widget.cpp
+# src/render_tools/manipulation_widget.cpp
   src/interactive_marker/integer_action.cpp
-#  src/interactive_marker/interactive_marker.cpp
-#  src/interactive_marker/interactive_marker_control.cpp
+# src/interactive_marker/interactive_marker.cpp
+# src/interactive_marker/interactive_marker_control.cpp
   src/markers/marker_base.cpp
   src/markers/marker_selection_handler.cpp
-#  src/markers/utils.cpp
+# src/markers/utils.cpp
   src/markers/arrow_marker.cpp
   src/markers/sphere_marker.cpp
   src/markers/cube_marker.cpp
@@ -100,35 +75,33 @@ add_library(${PROJECT_NAME}_render_tools SHARED
   src/markers/triangle_list_marker.cpp
   src/markers/text_view_facing_marker.cpp
   src/property/button_property.cpp
-  ${${PROJECT_NAME}_render_tools_cpp_MOCS}
+  #${${PROJECT_NAME}_render_tools_cpp_MOCS}
+  ${render_tools_qobjects}
 )
 target_link_libraries(${PROJECT_NAME}_render_tools PUBLIC
-  tesseract::tesseract
+  tesseract::tesseract_environment
+  tesseract::tesseract_motion_planners_core
+  tesseract::tesseract_visualization
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
   Qt5::Widgets
   rviz_common::rviz_common
-  rviz_rendering::rviz_rendering)
+  rviz_rendering::rviz_rendering
+)
 ament_target_dependencies(${PROJECT_NAME}_render_tools PUBLIC
   tesseract_msgs
+  tesseract_monitoring
   tesseract_rosutils
-#  ${OGRE_LIBRARIES}
 )
 
-target_compile_options(${PROJECT_NAME}_render_tools PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
-if(CXX_FEATURE_FOUND EQUAL "-1")
-    target_compile_options(${PROJECT_NAME}_render_tools PUBLIC -std=c++11)
-else()
-    target_compile_features(${PROJECT_NAME}_render_tools PUBLIC cxx_std_11)
-endif()
+target_compile_options(${PROJECT_NAME}_render_tools PUBLIC ${TESSERACT_COMPILE_OPTIONS})
+target_cxx_version(${PROJECT_NAME}_render_tools PUBLIC VERSION 17)
 target_include_directories(${PROJECT_NAME}_render_tools PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_render_tools SYSTEM PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>"
-#    ${OGRE_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS})
+target_compile_definitions(${PROJECT_NAME}_render_tools PUBLIC $ENV{ROS_DISTRO}_BUILD)
 
 #add_library(${PROJECT_NAME}_scene_plugin_core
 #  src/tesseract_scene_plugin/tesseract_scene_display.cpp
@@ -139,85 +112,60 @@ target_include_directories(${PROJECT_NAME}_render_tools SYSTEM PUBLIC
 #ament_add_dependencies(${PROJECT_NAME}_scene_plugin ${PROJECT_NAME}_scene_plugin_core ${Boost_LIBRARIES})
 
 # Trajectory State Display
-qt_wrap_cpp(${PROJECT_NAME}_state_plugin_core_cpp_MOCS include/tesseract_rviz/tesseract_state_plugin/tesseract_state_display.h)
+# qt_wrap_cpp(${PROJECT_NAME}_state_plugin_core_cpp_MOCS
+# include/tesseract_rviz/environment_state_plugin/environment_state_display.h)
 
-add_library(${PROJECT_NAME}_state_plugin_core SHARED src/tesseract_state_plugin/tesseract_state_display.cpp ${${PROJECT_NAME}_state_plugin_core_cpp_MOCS})
-target_link_libraries(${PROJECT_NAME}_state_plugin_core PUBLIC ${PROJECT_NAME}_render_tools)
-target_compile_options(${PROJECT_NAME}_state_plugin_core PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
-if(CXX_FEATURE_FOUND EQUAL "-1")
-    target_compile_options(${PROJECT_NAME}_state_plugin_core PUBLIC -std=c++14)
-else()
-    target_compile_features(${PROJECT_NAME}_state_plugin_core PUBLIC cxx_std_14)
-endif()
+add_library(${PROJECT_NAME}_state_plugin_core SHARED
+    src/environment_state_plugin/environment_state_display.cpp
+    include/tesseract_rviz/environment_state_plugin/environment_state_display.h)
+    # ${${PROJECT_NAME}_state_plugin_core_cpp_MOCS})
+target_link_libraries(${PROJECT_NAME}_state_plugin_core PUBLIC
+    ${PROJECT_NAME}_render_tools)
+target_compile_options(${PROJECT_NAME}_state_plugin_core PUBLIC ${TESSERACT_COMPILE_OPTIONS})
+target_cxx_version(${PROJECT_NAME}_state_plugin_core PUBLIC VERSION 17)
 target_include_directories(${PROJECT_NAME}_state_plugin_core PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_state_plugin_core SYSTEM PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>"
-#    ${OGRE_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME}_state_plugin SHARED src/tesseract_state_plugin/plugin_init.cpp)
+add_library(${PROJECT_NAME}_state_plugin SHARED src/environment_state_plugin/plugin_init.cpp)
 target_link_libraries(${PROJECT_NAME}_state_plugin PRIVATE ${PROJECT_NAME}_state_plugin_core)
-target_compile_options(${PROJECT_NAME}_state_plugin PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
-if(CXX_FEATURE_FOUND EQUAL "-1")
-    target_compile_options(${PROJECT_NAME}_state_plugin PUBLIC -std=c++14)
-else()
-    target_compile_features(${PROJECT_NAME}_state_plugin PUBLIC cxx_std_14)
-endif()
+target_compile_options(${PROJECT_NAME}_state_plugin PUBLIC ${TESSERACT_COMPILE_OPTIONS})
+target_cxx_version(${PROJECT_NAME}_state_plugin PUBLIC VERSION 17)
 target_include_directories(${PROJECT_NAME}_state_plugin PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_state_plugin SYSTEM PRIVATE
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
 
 ## Trajectory Display
-qt_wrap_cpp(${PROJECT_NAME}_trajectory_plugin_core_cpp_MOCS include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h)
+# qt5_wrap_cpp(${PROJECT_NAME}_trajectory_plugin_core_cpp_MOCS
+# include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h)
 
-add_library(${PROJECT_NAME}_trajectory_plugin_core SHARED src/tesseract_trajectory_plugin/tesseract_trajectory_display.cpp ${${PROJECT_NAME}_trajectory_plugin_core_cpp_MOCS})
+add_library(${PROJECT_NAME}_trajectory_plugin_core SHARED
+  src/tesseract_trajectory_plugin/tesseract_trajectory_display.cpp
+  include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h
+  #${${PROJECT_NAME}_trajectory_plugin_core_cpp_MOCS}
+)
 target_link_libraries(${PROJECT_NAME}_trajectory_plugin_core PUBLIC
   ${PROJECT_NAME}_render_tools
   ${PROJECT_NAME}_state_plugin_core
-  tesseract::tesseract
-#  ${OGRE_LIBRARIES}
-  )
-target_compile_options(${PROJECT_NAME}_trajectory_plugin_core PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
-if(CXX_FEATURE_FOUND EQUAL "-1")
-    target_compile_options(${PROJECT_NAME}_trajectory_plugin_core PUBLIC -std=c++11)
-else()
-    target_compile_features(${PROJECT_NAME}_trajectory_plugin_core PUBLIC cxx_std_11)
-endif()
+  tesseract::tesseract_environment
+)
+target_compile_options(${PROJECT_NAME}_trajectory_plugin_core PUBLIC ${TESSERACT_COMPILE_OPTIONS})
+target_cxx_version(${PROJECT_NAME}_trajectory_plugin_core PUBLIC VERSION 17)
 target_include_directories(${PROJECT_NAME}_trajectory_plugin_core PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_trajectory_plugin_core SYSTEM PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>"
-#    ${OGRE_INCLUDE_DIRS}
-#    ${EIGEN3_INCLUDE_DIRS}
-    )
 
 add_library(${PROJECT_NAME}_trajectory_plugin SHARED src/tesseract_trajectory_plugin/plugin_init.cpp)
 target_link_libraries(${PROJECT_NAME}_trajectory_plugin PRIVATE
     ${PROJECT_NAME}_trajectory_plugin_core
-    tesseract::tesseract
-    )
-target_compile_options(${PROJECT_NAME}_trajectory_plugin PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
-if(CXX_FEATURE_FOUND EQUAL "-1")
-    target_compile_options(${PROJECT_NAME}_trajectory_plugin PUBLIC -std=c++14)
-else()
-    target_compile_features(${PROJECT_NAME}_trajectory_plugin PUBLIC cxx_std_14)
-endif()
+    tesseract::tesseract_environment)
+target_compile_options(${PROJECT_NAME}_trajectory_plugin PUBLIC ${TESSERACT_COMPILE_OPTIONS})
+target_cxx_version(${PROJECT_NAME}_trajectory_plugin PUBLIC VERSION 17)
 target_include_directories(${PROJECT_NAME}_trajectory_plugin PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_trajectory_plugin SYSTEM PRIVATE
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>"
-#    ${EIGEN3_INCLUDE_DIRS}
-    )
 
 ### Manipulation Display
 #qt_wrap_cpp(${PROJECT_NAME}_manipulation_plugin_core_cpp_MOCS include/tesseract_rviz/tesseract_manipulation_plugin/tesseract_manipulation_display.h)
@@ -225,7 +173,7 @@ target_include_directories(${PROJECT_NAME}_trajectory_plugin SYSTEM PRIVATE
 #add_library(${PROJECT_NAME}_manipulation_plugin_core SHARED src/tesseract_manipulation_plugin/tesseract_manipulation_display.cpp ${${PROJECT_NAME}_manipulation_plugin_core_cpp_MOCS})
 #ament_add_dependencies(${PROJECT_NAME}_manipulation_plugin_core PUBLIC
 #    ${PROJECT_NAME}_render_tools
-#    tesseract::tesseract
+#    tesseract::tesseract_common
 #    ${OGRE_LIBRARIES}
 #    ${QT_LIBRARIES}
 #    ${Boost_LIBRARIES}
@@ -249,7 +197,7 @@ target_include_directories(${PROJECT_NAME}_trajectory_plugin SYSTEM PRIVATE
 #add_library(${PROJECT_NAME}_manipulation_plugin SHARED src/tesseract_manipulation_plugin/plugin_init.cpp)
 #ament_add_dependencies(${PROJECT_NAME}_manipulation_plugin PRIVATE
 #    ${PROJECT_NAME}_manipulation_plugin_core
-#    tesseract::tesseract
+#    tesseract::tesseract_common
 #    ${Boost_LIBRARIES})
 #target_compile_options(${PROJECT_NAME}_manipulation_plugin PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
 #if(CXX_FEATURE_FOUND EQUAL "-1")
@@ -267,24 +215,32 @@ target_include_directories(${PROJECT_NAME}_trajectory_plugin SYSTEM PRIVATE
 #    ${EIGEN3_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME}_test src/test.cpp)
-target_link_libraries(${PROJECT_NAME}_test PRIVATE ${PROJECT_NAME}_trajectory_plugin_core)
-target_compile_options(${PROJECT_NAME}_test PRIVATE -Wall -Wextra -Wsuggest-override -Wconversion -Wsign-conversion)
-if(CXX_FEATURE_FOUND EQUAL "-1")
-    target_compile_options(${PROJECT_NAME}_test PUBLIC -std=c++14)
-else()
-    target_compile_features(${PROJECT_NAME}_test PUBLIC cxx_std_14)
-endif()
+target_link_libraries(${PROJECT_NAME}_test PRIVATE
+  ${PROJECT_NAME}_state_plugin_core
+  ${PROJECT_NAME}_trajectory_plugin_core
+)
+target_compile_options(${PROJECT_NAME}_test PUBLIC ${TESSERACT_COMPILE_OPTIONS})
+target_cxx_version(${PROJECT_NAME}_test PUBLIC VERSION 17)
 target_include_directories(${PROJECT_NAME}_test PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_test SYSTEM PRIVATE
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+
+# Files generated by MOC, RCC, and UIC may produce clang-tidy warnings.
+# We generate a dummy .clang-tidy file in the binary directory that disables
+# all clang-tidy checks except one that will never match.  This one check is
+# necessary; clang-tidy reports an error when no checks are enabled.
+# Since the Qt code generators will generate source files in the binary tree,
+# clang-tidy will load the configuration from this dummy file when the sources
+# are built.
+#file(WRITE "${tesseract_rviz_BINARY_DIR}/.clang-tidy" "
+#---
+#Checks: '-*,llvm-twine-local'
+#...
+#")
 
 
 # Mark executables and/or libraries for installation
-install(TARGETS
-    ${PROJECT_NAME}_render_tools
+install(TARGETS ${PROJECT_NAME}_render_tools
     ${PROJECT_NAME}_state_plugin_core
     ${PROJECT_NAME}_state_plugin
     ${PROJECT_NAME}_trajectory_plugin_core
@@ -306,12 +262,14 @@ install(DIRECTORY include/
 )
 
 # Mark plugin XML files for installation
-install(FILES tesseract_rviz_state_plugin_description.xml tesseract_rviz_trajectory_plugin_description.xml #tesseract_rviz_manipulation_plugin_description.xml
+install(FILES tesseract_rviz_state_plugin_description.xml
+  tesseract_rviz_trajectory_plugin_description.xml
+# tesseract_rviz_manipulation_plugin_description.xml
   DESTINATION share/${PROJECT_NAME}
 )
 pluginlib_export_plugin_description_file(rviz_common tesseract_rviz_state_plugin_description.xml)
 pluginlib_export_plugin_description_file(rviz_common tesseract_rviz_trajectory_plugin_description.xml)
-#pluginlib_export_plugin_description_file(rviz_common tesseract_rviz_manipulation_plugin_description.xml)
+# pluginlib_export_plugin_description_file(rviz_common tesseract_rviz_manipulation_plugin_description.xml)
 
 ament_export_dependencies(
     ament_cmake

--- a/tesseract_rviz/CMakeLists.txt
+++ b/tesseract_rviz/CMakeLists.txt
@@ -36,7 +36,6 @@ set(CMAKE_AUTOMOC ON)
 tesseract_variables()
 
 # Rviz Render Tools
-# qt5_wrap_cpp(${PROJECT_NAME}_render_tools_cpp_MOCS
 set(render_tools_qobjects
   include/tesseract_rviz/render_tools/trajectory_panel.h
   include/tesseract_rviz/render_tools/visualization_widget.h
@@ -45,7 +44,7 @@ set(render_tools_qobjects
   include/tesseract_rviz/render_tools/joint_widget.h
   include/tesseract_rviz/render_tools/joint_state_monitor_widget.h
   include/tesseract_rviz/render_tools/environment_widget.h
-# include/tesseract_rviz/render_tools/trajectory_monitor_widget.h
+  include/tesseract_rviz/render_tools/trajectory_monitor_widget.h
 # include/tesseract_rviz/render_tools/manipulation_widget.h
   include/tesseract_rviz/interactive_marker/integer_action.h
 # include/tesseract_rviz/interactive_marker/interactive_marker.h
@@ -60,7 +59,7 @@ add_library(${PROJECT_NAME}_render_tools SHARED
   src/render_tools/trajectory_panel.cpp
   src/render_tools/joint_state_monitor_widget.cpp
   src/render_tools/environment_widget.cpp
-# src/render_tools/trajectory_monitor_widget.cpp
+  src/render_tools/trajectory_monitor_widget.cpp
 # src/render_tools/manipulation_widget.cpp
   src/interactive_marker/integer_action.cpp
 # src/interactive_marker/interactive_marker.cpp
@@ -75,7 +74,6 @@ add_library(${PROJECT_NAME}_render_tools SHARED
   src/markers/triangle_list_marker.cpp
   src/markers/text_view_facing_marker.cpp
   src/property/button_property.cpp
-  #${${PROJECT_NAME}_render_tools_cpp_MOCS}
   ${render_tools_qobjects}
 )
 target_link_libraries(${PROJECT_NAME}_render_tools PUBLIC
@@ -93,7 +91,6 @@ ament_target_dependencies(${PROJECT_NAME}_render_tools PUBLIC
   tesseract_monitoring
   tesseract_rosutils
 )
-
 target_compile_options(${PROJECT_NAME}_render_tools PUBLIC ${TESSERACT_COMPILE_OPTIONS})
 target_cxx_version(${PROJECT_NAME}_render_tools PUBLIC VERSION 17)
 target_include_directories(${PROJECT_NAME}_render_tools PUBLIC
@@ -111,14 +108,11 @@ target_compile_definitions(${PROJECT_NAME}_render_tools PUBLIC $ENV{ROS_DISTRO}_
 #add_library(${PROJECT_NAME}_scene_plugin src/tesseract_scene_plugin/plugin_init.cpp)
 #ament_add_dependencies(${PROJECT_NAME}_scene_plugin ${PROJECT_NAME}_scene_plugin_core ${Boost_LIBRARIES})
 
-# Trajectory State Display
-# qt_wrap_cpp(${PROJECT_NAME}_state_plugin_core_cpp_MOCS
-# include/tesseract_rviz/environment_state_plugin/environment_state_display.h)
-
+# Environment State Display
 add_library(${PROJECT_NAME}_state_plugin_core SHARED
     src/environment_state_plugin/environment_state_display.cpp
-    include/tesseract_rviz/environment_state_plugin/environment_state_display.h)
-    # ${${PROJECT_NAME}_state_plugin_core_cpp_MOCS})
+    include/tesseract_rviz/environment_state_plugin/environment_state_display.h
+)
 target_link_libraries(${PROJECT_NAME}_state_plugin_core PUBLIC
     ${PROJECT_NAME}_render_tools)
 target_compile_options(${PROJECT_NAME}_state_plugin_core PUBLIC ${TESSERACT_COMPILE_OPTIONS})
@@ -137,14 +131,10 @@ target_include_directories(${PROJECT_NAME}_state_plugin PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 
-## Trajectory Display
-# qt5_wrap_cpp(${PROJECT_NAME}_trajectory_plugin_core_cpp_MOCS
-# include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h)
-
+# Trajectory Display
 add_library(${PROJECT_NAME}_trajectory_plugin_core SHARED
   src/tesseract_trajectory_plugin/tesseract_trajectory_display.cpp
   include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h
-  #${${PROJECT_NAME}_trajectory_plugin_core_cpp_MOCS}
 )
 target_link_libraries(${PROJECT_NAME}_trajectory_plugin_core PUBLIC
   ${PROJECT_NAME}_render_tools
@@ -239,7 +229,7 @@ target_include_directories(${PROJECT_NAME}_test PRIVATE
 #")
 
 
-# Mark executables and/or libraries for installation
+# Install libraries
 install(TARGETS ${PROJECT_NAME}_render_tools
     ${PROJECT_NAME}_state_plugin_core
     ${PROJECT_NAME}_state_plugin
@@ -254,6 +244,7 @@ install(TARGETS ${PROJECT_NAME}_render_tools
     INCLUDES DESTINATION include
 )
 
+# Install executables
 install(TARGETS ${PROJECT_NAME}_test DESTINATION lib/${PROJECT_NAME})
 
 # Mark cpp header files for installation
@@ -291,5 +282,5 @@ ament_export_dependencies(
     console_bridge
     Eigen3)
 
-ament_export_interfaces(${PACKAGE_NAME}-targets)
+ament_export_targets(${PACKAGE_NAME}-targets)
 ament_package()

--- a/tesseract_rviz/include/tesseract_rviz/environment_state_plugin/environment_state_display.h
+++ b/tesseract_rviz/include/tesseract_rviz/environment_state_plugin/environment_state_display.h
@@ -39,13 +39,13 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <rviz/display.h>
+#include <rviz_common/display.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #ifndef Q_MOC_RUN
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <ros/ros.h>
-#include <tesseract_environment/environment.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tesseract/tesseract.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #endif
 
@@ -55,16 +55,16 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_rviz
 {
-class EnvironmentStateDisplay : public rviz::Display
+class TesseractStateDisplay : public rviz_common::Display
 {
   Q_OBJECT
 
 public:
-  using Ptr = std::shared_ptr<EnvironmentStateDisplay>;
-  using ConstPtr = std::shared_ptr<const EnvironmentStateDisplay>;
+  using SharedPtr = std::shared_ptr<TesseractStateDisplay>;
+  using ConstSharedPtr = std::shared_ptr<const TesseractStateDisplay>;
 
-  EnvironmentStateDisplay();
-  ~EnvironmentStateDisplay() override;
+  TesseractStateDisplay();
+  ~TesseractStateDisplay() override;
 
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
@@ -79,12 +79,12 @@ protected:
   void onDisable() override;
   //  void fixedFrameChanged() override;
 
-  ros::NodeHandle nh_;
+  rclcpp::Node::SharedPtr node_;
 
-  tesseract_environment::Environment::Ptr env_;
-  VisualizationWidget::Ptr visualization_;
-  JointStateMonitorWidget::Ptr state_monitor_;
-  EnvironmentWidget::Ptr environment_monitor_;
+  tesseract::Tesseract::Ptr tesseract_;
+  VisualizationWidget::SharedPtr visualization_;
+  JointStateMonitorWidget::SharedPtr state_monitor_;
+  EnvironmentWidget::SharedPtr environment_monitor_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/environment_state_plugin/environment_state_display.h
+++ b/tesseract_rviz/include/tesseract_rviz/environment_state_plugin/environment_state_display.h
@@ -80,7 +80,6 @@ protected:
   //  void fixedFrameChanged() override;
 
   rclcpp::Node::SharedPtr node_ = nullptr;
-  rclcpp::TimerBase::SharedPtr timer_;
 
   tesseract_environment::Environment::Ptr env_;
   VisualizationWidget::Ptr visualization_;

--- a/tesseract_rviz/include/tesseract_rviz/environment_state_plugin/environment_state_display.h
+++ b/tesseract_rviz/include/tesseract_rviz/environment_state_plugin/environment_state_display.h
@@ -45,7 +45,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #ifndef Q_MOC_RUN
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <rclcpp/rclcpp.hpp>
-#include <tesseract/tesseract.h>
+#include <tesseract_environment/environment.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #endif
 
@@ -55,16 +55,16 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_rviz
 {
-class TesseractStateDisplay : public rviz_common::Display
+class EnvironmentStateDisplay : public rviz_common::Display
 {
   Q_OBJECT
 
 public:
-  using SharedPtr = std::shared_ptr<TesseractStateDisplay>;
-  using ConstSharedPtr = std::shared_ptr<const TesseractStateDisplay>;
+  using Ptr = std::shared_ptr<EnvironmentStateDisplay>;
+  using ConstPtr = std::shared_ptr<const EnvironmentStateDisplay>;
 
-  TesseractStateDisplay();
-  ~TesseractStateDisplay() override;
+  EnvironmentStateDisplay();
+  ~EnvironmentStateDisplay() override;
 
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
@@ -79,12 +79,13 @@ protected:
   void onDisable() override;
   //  void fixedFrameChanged() override;
 
-  rclcpp::Node::SharedPtr node_;
+  rclcpp::Node::SharedPtr node_ = nullptr;
+  rclcpp::TimerBase::SharedPtr timer_;
 
-  tesseract::Tesseract::Ptr tesseract_;
-  VisualizationWidget::SharedPtr visualization_;
-  JointStateMonitorWidget::SharedPtr state_monitor_;
-  EnvironmentWidget::SharedPtr environment_monitor_;
+  tesseract_environment::Environment::Ptr env_;
+  VisualizationWidget::Ptr visualization_;
+  JointStateMonitorWidget::Ptr state_monitor_;
+  EnvironmentWidget::Ptr environment_widget_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/interactive_marker/interactive_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/interactive_marker/interactive_marker.h
@@ -64,8 +64,8 @@ class InteractiveMarker : public QObject
 {
   Q_OBJECT
 public:
-  using SharedPtr = std::shared_ptr<InteractiveMarker>;
-  using ConstSharedPtr = std::shared_ptr<const InteractiveMarker>;
+  using Ptr = std::shared_ptr<InteractiveMarker>;
+  using ConstPtr = std::shared_ptr<const InteractiveMarker>;
 
   InteractiveMarker(const std::string& name,
                     const std::string& description,
@@ -76,7 +76,7 @@ public:
                     const float scale = 1);
   virtual ~InteractiveMarker();
 
-  InteractiveMarkerControl::SharedPtr createInteractiveControl(const std::string& name,
+  InteractiveMarkerControl::Ptr createInteractiveControl(const std::string& name,
                                                          const std::string& description,
                                                          const InteractiveMode interactive_mode,
                                                          const OrientationMode orientation_mode,
@@ -99,11 +99,11 @@ public:
   void startDragging();
   void stopDragging();
 
-  const Ogre::Vector3& getPosition() { return position_; }
-  const Ogre::Quaternion& getOrientation() { return orientation_; }
+  const Ogre::Vector3& getPosition() const { return position_; }
+  const Ogre::Quaternion& getOrientation() const { return orientation_; }
 
   void setSize(float scale);
-  float getSize() { return scale_; }
+  float getSize() const { return scale_; }
   const std::string& getReferenceFrame() { return reference_frame_; }
   const std::string& getName() { return name_; }
 
@@ -167,8 +167,8 @@ public:
 Q_SIGNALS:
 
   void userFeedback(std::string reference_frame,
-                    Eigen::Isometry3d transform,
-                    Eigen::Vector3d mouse_point,
+                    const Eigen::Isometry3d& transform,
+                    const Eigen::Vector3d& mouse_point,
                     bool mouse_point_valid);
   void statusUpdate(rviz_common::properties::StatusProperty::Level level, const std::string& name, const std::string& text);
 
@@ -217,7 +217,7 @@ protected:
   bool pose_changed_;
   double time_since_last_feedback_;
 
-  std::map<std::string, InteractiveMarkerControl::SharedPtr> controls_;
+  std::map<std::string, InteractiveMarkerControl::Ptr> controls_;
 
   std::string name_;
   std::string description_;
@@ -254,7 +254,7 @@ protected:
 
   rviz_rendering::Axes* axes_;
 
-  InteractiveMarkerControl::SharedPtr description_control_;
+  InteractiveMarkerControl::Ptr description_control_;
 
   std::string topic_ns_;
   std::string client_id_;

--- a/tesseract_rviz/include/tesseract_rviz/interactive_marker/interactive_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/interactive_marker/interactive_marker.h
@@ -42,9 +42,9 @@
 #include <tesseract_rviz/interactive_marker/interactive_marker_control.h>
 #endif
 
-#include "rviz/selection/forwards.h"
-#include "rviz/ogre_helpers/axes.h"
-#include "rviz/properties/status_property.h"
+#include "rviz_common/interaction/forwards.hpp"
+#include "rviz_rendering/objects/axes.hpp"
+#include "rviz_common/properties/status_property.hpp"
 
 namespace Ogre
 {
@@ -64,19 +64,19 @@ class InteractiveMarker : public QObject
 {
   Q_OBJECT
 public:
-  using Ptr = boost::shared_ptr<InteractiveMarker>;
-  using ConstPtr = boost::shared_ptr<const InteractiveMarker>;
+  using SharedPtr = std::shared_ptr<InteractiveMarker>;
+  using ConstSharedPtr = std::shared_ptr<const InteractiveMarker>;
 
-  InteractiveMarker(std::string name,
-                    std::string description,
-                    std::string reference_frame,
+  InteractiveMarker(const std::string& name,
+                    const std::string& description,
+                    const std::string& reference_frame,
                     Ogre::SceneNode* scene_node,
-                    rviz::DisplayContext* context,
-                    bool reference_frame_locked,
-                    float scale = 1);
+                    rviz_common::DisplayContext* context,
+                    const bool reference_frame_locked,
+                    const float scale = 1);
   virtual ~InteractiveMarker();
 
-  InteractiveMarkerControl::Ptr createInteractiveControl(const std::string& name,
+  InteractiveMarkerControl::SharedPtr createInteractiveControl(const std::string& name,
                                                          const std::string& description,
                                                          const InteractiveMode interactive_mode,
                                                          const OrientationMode orientation_mode,
@@ -123,7 +123,7 @@ public:
   void setShowVisualAids(bool show);
 
   // @return true if the mouse event was intercepted, false if it was ignored
-  bool handleMouseEvent(rviz::ViewportMouseEvent& event, const std::string& control_name);
+  bool handleMouseEvent(rviz_common::ViewportMouseEvent& event, const std::string& control_name);
 
   /**
    * Supports selection and menu events from a 3D cursor.
@@ -135,7 +135,7 @@ public:
    * @param  control_name The name of the child InteractiveMarkerControl calling this function.
    * @return              true if the cursor event was intercepted, false if it was ignored
    */
-  bool handle3DCursorEvent(rviz::ViewportMouseEvent& event,
+  bool handle3DCursorEvent(rviz_common::ViewportMouseEvent& event,
                            const Ogre::Vector3& cursor_pos,
                            const Ogre::Quaternion& cursor_rot,
                            const std::string& control_name);
@@ -150,7 +150,7 @@ public:
    * @param  valid_point   True if three_d_point is valid (e.g. if the mouse ray was successfully intersected with
    * marker geometry).
    */
-  void showMenu(rviz::ViewportMouseEvent& event,
+  void showMenu(rviz_common::ViewportMouseEvent& event,
                 const std::string& control_name,
                 const Ogre::Vector3& three_d_point,
                 bool valid_point);
@@ -162,15 +162,15 @@ public:
   bool hasMenu() { return has_menu_; }
 
   /** @return A shared_ptr to the QMenu owned by this InteractiveMarker. */
-  boost::shared_ptr<QMenu> getMenu() { return menu_; }
+  std::shared_ptr<QMenu> getMenu() { return menu_; }
 
 Q_SIGNALS:
 
   void userFeedback(std::string reference_frame,
-                    const Eigen::Isometry3d& transform,
-                    const Eigen::Vector3d& mouse_point,
+                    Eigen::Isometry3d transform,
+                    Eigen::Vector3d mouse_point,
                     bool mouse_point_valid);
-  void statusUpdate(rviz::StatusProperty::Level level, const std::string& name, const std::string& text);
+  void statusUpdate(rviz_common::properties::StatusProperty::Level level, const std::string& name, const std::string& text);
 
 protected Q_SLOTS:
   void handleMenuSelect(int menu_item_id);
@@ -200,7 +200,7 @@ protected:
   void updateVisualAidsVisibility();
 
   bool visible_;
-  rviz::DisplayContext* context_;
+  rviz_common::DisplayContext* context_;
 
   // pose of parent coordinate frame
   std::string reference_frame_;
@@ -217,7 +217,7 @@ protected:
   bool pose_changed_;
   double time_since_last_feedback_;
 
-  std::map<std::string, InteractiveMarkerControl::Ptr> controls_;
+  std::map<std::string, InteractiveMarkerControl::SharedPtr> controls_;
 
   std::string name_;
   std::string description_;
@@ -231,7 +231,7 @@ protected:
 
   float scale_;
 
-  boost::shared_ptr<QMenu> menu_;
+  std::shared_ptr<QMenu> menu_;
   bool has_menu_;
 
   // Helper to more simply represent the menu tree.
@@ -252,16 +252,16 @@ protected:
 
   // visual aids
 
-  rviz::Axes* axes_;
+  rviz_rendering::Axes* axes_;
 
-  InteractiveMarkerControl::Ptr description_control_;
+  InteractiveMarkerControl::SharedPtr description_control_;
 
   std::string topic_ns_;
   std::string client_id_;
 
   boost::recursive_mutex mutex_;
 
-  boost::shared_ptr<boost::thread> sys_thread_;
+  std::shared_ptr<boost::thread> sys_thread_;
 
   bool got_3d_point_for_menu_;
   Ogre::Vector3 three_d_point_for_menu_;

--- a/tesseract_rviz/include/tesseract_rviz/interactive_marker/interactive_marker_control.h
+++ b/tesseract_rviz/include/tesseract_rviz/interactive_marker/interactive_marker_control.h
@@ -42,6 +42,7 @@
 #endif
 
 #include <QCursor>
+#include <QString>
 
 #include "rviz_common/interaction/forwards.hpp"
 #include "rviz_common/viewport_mouse_event.hpp"
@@ -95,14 +96,14 @@ enum class OrientationMode
  */
 class InteractiveMarkerControl : public Ogre::SceneManager::Listener,
                                  public rviz_common::InteractiveObject,
-                                 public boost::enable_shared_from_this<InteractiveMarkerControl>
+                                 public std::enable_shared_from_this<InteractiveMarkerControl>
 {
 public:
-  using SharedPtr = std::shared_ptr<InteractiveMarkerControl>;
-  using ConstSharedPtr = std::shared_ptr<const InteractiveMarkerControl>;
+  using Ptr = std::shared_ptr<InteractiveMarkerControl>;
+  using ConstPtr = std::shared_ptr<const InteractiveMarkerControl>;
 
-  InteractiveMarkerControl(const std::string& name,
-                           const std::string& description,
+  InteractiveMarkerControl(std::string name,
+                           std::string description,
                            rviz_common::DisplayContext* context,
                            Ogre::SceneNode* reference_node,
                            InteractiveMarker* parent,
@@ -123,13 +124,13 @@ public:
    * @brief Add marker to the controller
    * @param marker to add to the controller
    */
-  void addMarker(MarkerBase::SharedPtr marker);
+  void addMarker(const MarkerBase::Ptr& marker);
 
   // called when interactive mode is globally switched on/off
-  virtual void enableInteraction(bool enable);
+  virtual void enableInteraction(bool enable) override;
 
   // will receive all mouse events while the handler has focus
-  virtual void handleMouseEvent(rviz_common::ViewportMouseEvent& event);
+  virtual void handleMouseEvent(rviz_common::ViewportMouseEvent& event) override;
 
   /**
    * This is the main entry-point for interaction using a 3D cursor.
@@ -167,7 +168,7 @@ public:
    * function on all its child controls. */
   void interactiveMarkerPoseChanged(Ogre::Vector3 int_marker_position, Ogre::Quaternion int_marker_orientation);
 
-  bool isInteractive() { return interaction_mode_ != InteractiveMode::NONE; }
+  bool isInteractive() override { return interaction_mode_ != InteractiveMode::NONE; }
 
   // Called every frame by parent's update() function.
   void update();
@@ -244,7 +245,7 @@ protected:
   // when this is called, we will face the camera
   virtual void preFindVisibleObjects(Ogre::SceneManager* source,
                                      Ogre::SceneManager::IlluminationRenderStage irs,
-                                     Ogre::Viewport* v);
+                                     Ogre::Viewport* v) override;
 
   void updateControlOrientationForViewFacing(Ogre::Viewport* v);
 
@@ -322,7 +323,7 @@ protected:
 
   /// compute intersection between mouse ray and a y-z plane.
   bool intersectSomeYzPlane(const Ogre::Ray& mouse_ray,
-                            const Ogre::Vector3& point_in_plane,
+                            const Ogre::Vector3& point_on_plane,
                             const Ogre::Quaternion& plane_orientation,
                             Ogre::Vector3& intersection_3d,
                             Ogre::Vector2& intersection_2d,
@@ -338,7 +339,7 @@ protected:
   void worldToScreen(const Ogre::Vector3& pos_rel_reference, const Ogre::Viewport* viewport, Ogre::Vector2& screen_pos);
 
   //  /// take all the materials, add a highlight pass and store a pointer to the pass for later use
-  void addHighlightPass(std::set<Ogre::MaterialPtr> materials);
+  void addHighlightPass(const std::set<Ogre::MaterialPtr>& materials);
 
   // set the highlight color to (a,a,a)
   void setHighlight(float a);
@@ -364,16 +365,16 @@ protected:
 
   void stopDragging(bool force = false);
 
-  virtual const QCursor& getCursor() const { return cursor_; }
+  virtual const QCursor& getCursor() const override { return cursor_; }
 
   bool mouse_dragging_;
   Ogre::Viewport* drag_viewport_;
 
-  rviz_common::ViewportMouseEvent dragging_in_place_event_;
+  std::unique_ptr<rviz_common::ViewportMouseEvent> dragging_in_place_event_;
 
   rviz_common::DisplayContext* context_;
 
-  rviz_common::CollObjectHandle coll_object_handle_;
+  rviz_common::interaction::CollObjectHandle coll_object_handle_;
 
   /** Node representing reference frame in tf, like /map, /base_link,
    * /head, etc.  Same as the field in InteractiveMarker. */
@@ -459,7 +460,7 @@ protected:
   Ogre::Ray mouse_ray_at_drag_begin_;
 
   /* how far to move in Z when mouse moves 1 pixel. */
-  double mouse_z_scale_;
+  Ogre::Real mouse_z_scale_;
 
   /** offset of the absolute mouse position from the relative mouse position */
   int mouse_relative_to_absolute_x_;

--- a/tesseract_rviz/include/tesseract_rviz/interactive_marker/interactive_marker_control.h
+++ b/tesseract_rviz/include/tesseract_rviz/interactive_marker/interactive_marker_control.h
@@ -43,9 +43,9 @@
 
 #include <QCursor>
 
-#include "rviz/selection/forwards.h"
-#include "rviz/viewport_mouse_event.h"
-#include "rviz/interactive_object.h"
+#include "rviz_common/interaction/forwards.hpp"
+#include "rviz_common/viewport_mouse_event.hpp"
+#include "rviz_common/interactive_object.hpp"
 
 namespace Ogre
 {
@@ -94,16 +94,16 @@ enum class OrientationMode
  * A single control element of an InteractiveMarker.
  */
 class InteractiveMarkerControl : public Ogre::SceneManager::Listener,
-                                 public rviz::InteractiveObject,
+                                 public rviz_common::InteractiveObject,
                                  public boost::enable_shared_from_this<InteractiveMarkerControl>
 {
 public:
-  using Ptr = boost::shared_ptr<InteractiveMarkerControl>;
-  using ConstPtr = boost::shared_ptr<const InteractiveMarkerControl>;
+  using SharedPtr = std::shared_ptr<InteractiveMarkerControl>;
+  using ConstSharedPtr = std::shared_ptr<const InteractiveMarkerControl>;
 
-  InteractiveMarkerControl(std::string name,
+  InteractiveMarkerControl(const std::string& name,
                            const std::string& description,
-                           rviz::DisplayContext* context,
+                           rviz_common::DisplayContext* context,
                            Ogre::SceneNode* reference_node,
                            InteractiveMarker* parent,
                            const InteractiveMode interactive_mode,
@@ -123,13 +123,13 @@ public:
    * @brief Add marker to the controller
    * @param marker to add to the controller
    */
-  void addMarker(const MarkerBase::Ptr& marker);
+  void addMarker(MarkerBase::SharedPtr marker);
 
   // called when interactive mode is globally switched on/off
-  virtual void enableInteraction(bool enable) override;
+  virtual void enableInteraction(bool enable);
 
   // will receive all mouse events while the handler has focus
-  virtual void handleMouseEvent(rviz::ViewportMouseEvent& event) override;
+  virtual void handleMouseEvent(rviz_common::ViewportMouseEvent& event);
 
   /**
    * This is the main entry-point for interaction using a 3D cursor.
@@ -156,7 +156,7 @@ public:
    * @param  cursor_rot   The world-relative orientation of the 3D cursor.
    * @param  control_name The name of the child InteractiveMarkerControl calling this function.
    */
-  virtual void handle3DCursorEvent(rviz::ViewportMouseEvent event,
+  virtual void handle3DCursorEvent(rviz_common::ViewportMouseEvent event,
                                    const Ogre::Vector3& cursor_3D_pos,
                                    const Ogre::Quaternion& cursor_3D_orientation);
 
@@ -167,7 +167,7 @@ public:
    * function on all its child controls. */
   void interactiveMarkerPoseChanged(Ogre::Vector3 int_marker_position, Ogre::Quaternion int_marker_orientation);
 
-  bool isInteractive() override { return interaction_mode_ != InteractiveMode::NONE; }
+  bool isInteractive() { return interaction_mode_ != InteractiveMode::NONE; }
 
   // Called every frame by parent's update() function.
   void update();
@@ -222,7 +222,7 @@ public:
    * @brief Get the display context
    * @return Display context
    */
-  rviz::DisplayContext* getDisplayContext() { return context_; }
+  rviz_common::DisplayContext* getDisplayContext() { return context_; }
 
   /**
    * @brief Get the size of the ineractive control
@@ -244,35 +244,35 @@ protected:
   // when this is called, we will face the camera
   virtual void preFindVisibleObjects(Ogre::SceneManager* source,
                                      Ogre::SceneManager::IlluminationRenderStage irs,
-                                     Ogre::Viewport* v) override;
+                                     Ogre::Viewport* v);
 
   void updateControlOrientationForViewFacing(Ogre::Viewport* v);
 
   /** calculate a mouse ray in the reference frame.
    *  A mouse ray is a ray starting at the camera and pointing towards the mouse position. */
-  Ogre::Ray getMouseRayInReferenceFrame(const rviz::ViewportMouseEvent& event, int x, int y);
+  Ogre::Ray getMouseRayInReferenceFrame(const rviz_common::ViewportMouseEvent& event, int x, int y);
 
   /** begin a relative-motion drag. */
-  void beginRelativeMouseMotion(const rviz::ViewportMouseEvent& event);
+  void beginRelativeMouseMotion(const rviz_common::ViewportMouseEvent& event);
 
   /** get the relative motion of the mouse, and put the mouse back
    *  where it was when beginRelativeMouseMotion() was called. */
-  bool getRelativeMouseMotion(const rviz::ViewportMouseEvent& event, int& dx, int& dy);
+  bool getRelativeMouseMotion(const rviz_common::ViewportMouseEvent& event, int& dx, int& dy);
 
   /** Rotate the pose around the camera-frame XY (right/up) axes, based on relative mouse movement. */
-  void rotateXYRelative(const rviz::ViewportMouseEvent& event);
+  void rotateXYRelative(const rviz_common::ViewportMouseEvent& event);
 
   /** Rotate the pose around the camera-frame Z (look) axis, based on relative mouse movement. */
-  void rotateZRelative(const rviz::ViewportMouseEvent& event);
+  void rotateZRelative(const rviz_common::ViewportMouseEvent& event);
 
   /** Move the pose along the mouse ray, based on relative mouse movement. */
-  void moveZAxisRelative(const rviz::ViewportMouseEvent& event);
+  void moveZAxisRelative(const rviz_common::ViewportMouseEvent& event);
 
   /** Move the pose along the mouse ray, based on mouse wheel movement. */
-  void moveZAxisWheel(const rviz::ViewportMouseEvent& event);
+  void moveZAxisWheel(const rviz_common::ViewportMouseEvent& event);
 
   /** Move the pose around the XY view plane (perpendicular to the camera direction). */
-  void moveViewPlane(Ogre::Ray& mouse_ray, const rviz::ViewportMouseEvent& event);
+  void moveViewPlane(Ogre::Ray& mouse_ray, const rviz_common::ViewportMouseEvent& event);
 
   /** Rotate the pose around the local X-axis, following the mouse movement.
    *  mouse_ray is relative to the reference frame. */
@@ -297,7 +297,7 @@ protected:
 
   /** Translate along the local X-axis, following the mouse movement.
    *  mouse_ray is relative to the reference frame. */
-  void moveAxis(const Ogre::Ray& mouse_ray, const rviz::ViewportMouseEvent& event);
+  void moveAxis(const Ogre::Ray& mouse_ray, const rviz_common::ViewportMouseEvent& event);
 
   /** Translate along the local X-axis, following the 3D cursor movement. */
   void moveAxis(const Ogre::Vector3& cursor_position_in_reference_frame);
@@ -322,7 +322,7 @@ protected:
 
   /// compute intersection between mouse ray and a y-z plane.
   bool intersectSomeYzPlane(const Ogre::Ray& mouse_ray,
-                            const Ogre::Vector3& point_on_plane,
+                            const Ogre::Vector3& point_in_plane,
                             const Ogre::Quaternion& plane_orientation,
                             Ogre::Vector3& intersection_3d,
                             Ogre::Vector2& intersection_2d,
@@ -338,7 +338,7 @@ protected:
   void worldToScreen(const Ogre::Vector3& pos_rel_reference, const Ogre::Viewport* viewport, Ogre::Vector2& screen_pos);
 
   //  /// take all the materials, add a highlight pass and store a pointer to the pass for later use
-  void addHighlightPass(const std::set<Ogre::MaterialPtr>& materials);
+  void addHighlightPass(std::set<Ogre::MaterialPtr> materials);
 
   // set the highlight color to (a,a,a)
   void setHighlight(float a);
@@ -346,16 +346,16 @@ protected:
   // Save a copy of the latest mouse event with the event type set to
   // QEvent::MouseMove, so that update() can resend the mouse event during
   // drag actions to maintain consistent behavior.
-  void recordDraggingInPlaceEvent(rviz::ViewportMouseEvent& event);
+  void recordDraggingInPlaceEvent(rviz_common::ViewportMouseEvent& event);
 
   // Begin a new mouse motion.  Called when left button is pressed to begin a drag.
-  void beginMouseMovement(rviz::ViewportMouseEvent& event, bool line_visible);
+  void beginMouseMovement(rviz_common::ViewportMouseEvent& event, bool line_visible);
 
   // Motion part of mouse event handling.
-  void handleMouseMovement(rviz::ViewportMouseEvent& event);
+  void handleMouseMovement(rviz_common::ViewportMouseEvent& event);
 
   // Mouse wheel part of mouse event handling.
-  void handleMouseWheelMovement(rviz::ViewportMouseEvent& event);
+  void handleMouseWheelMovement(rviz_common::ViewportMouseEvent& event);
 
   // Return closest point on a line to a test point.
   Ogre::Vector3 closestPointOnLineToPoint(const Ogre::Vector3& line_start,
@@ -364,16 +364,16 @@ protected:
 
   void stopDragging(bool force = false);
 
-  virtual const QCursor& getCursor() const override { return cursor_; }
+  virtual const QCursor& getCursor() const { return cursor_; }
 
   bool mouse_dragging_;
   Ogre::Viewport* drag_viewport_;
 
-  rviz::ViewportMouseEvent dragging_in_place_event_;
+  rviz_common::ViewportMouseEvent dragging_in_place_event_;
 
-  rviz::DisplayContext* context_;
+  rviz_common::DisplayContext* context_;
 
-  rviz::CollObjectHandle coll_object_handle_;
+  rviz_common::CollObjectHandle coll_object_handle_;
 
   /** Node representing reference frame in tf, like /map, /base_link,
    * /head, etc.  Same as the field in InteractiveMarker. */
@@ -411,7 +411,7 @@ protected:
 
   std::string name_;
 
-  std::vector<boost::shared_ptr<MarkerBase>> markers_;
+  std::vector<std::shared_ptr<MarkerBase>> markers_;
 
   InteractiveMarker* parent_;
 
@@ -420,7 +420,7 @@ protected:
   //  // PointsMarkers are rendered by special shader programs, so the
   //  // regular highlighting method does not work for them.  Keep a
   //  // vector of them so we can call their setHighlightColor() function.
-  //  typedef boost::shared_ptr<PointsMarker> PointsMarkerPtr;
+  //  typedef std::shared_ptr<PointsMarker> PointsMarkerPtr;
   //  std::vector< PointsMarkerPtr > points_markers_;
 
   /** Stores the rotation around the x axis of the control.  Only
@@ -459,7 +459,7 @@ protected:
   Ogre::Ray mouse_ray_at_drag_begin_;
 
   /* how far to move in Z when mouse moves 1 pixel. */
-  Ogre::Real mouse_z_scale_;
+  double mouse_z_scale_;
 
   /** offset of the absolute mouse position from the relative mouse position */
   int mouse_relative_to_absolute_x_;
@@ -503,7 +503,7 @@ protected:
 
   bool mouse_down_;
 
-  //  boost::shared_ptr<Line> line_;
+  //  std::shared_ptr<Line> line_;
 
   bool show_visual_aids_;
 };

--- a/tesseract_rviz/include/tesseract_rviz/markers/arrow_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/arrow_marker.h
@@ -39,27 +39,30 @@ namespace Ogre
 class SceneNode;
 }
 
-namespace rviz
+namespace rviz_common
 {
-class Arrow;
 class DisplayContext;
 }  // namespace rviz
+
+namespace rviz_rendering {
+class Arrow;
+}
 
 namespace tesseract_rviz
 {
 class ArrowMarker : public MarkerBase
 {
 public:
-  using Ptr = boost::shared_ptr<ArrowMarker>;
-  using ConstPtr = boost::shared_ptr<const ArrowMarker>;
+  using SharedPtr = std::shared_ptr<ArrowMarker>;
+  using ConstSharedPtr = std::shared_ptr<const ArrowMarker>;
 
-  ArrowMarker(const std::string& ns, const int id, rviz::DisplayContext* context, Ogre::SceneNode* parent_node);
+  ArrowMarker(const std::string& ns, const int id, rviz_common::DisplayContext* context, Ogre::SceneNode* parent_node);
 
   ArrowMarker(const std::string& ns,
               const int id,
               Ogre::Vector3 point1,
               Ogre::Vector3 point2,
-              rviz::DisplayContext* context,
+              rviz_common::DisplayContext* context,
               Ogre::SceneNode* parent_node);
 
   ~ArrowMarker() override;
@@ -74,7 +77,7 @@ public:
 protected:
   virtual void setDefaultProportions();
 
-  rviz::Arrow* arrow_;
+  rviz_rendering::Arrow* arrow_;
   Ogre::SceneNode* child_scene_node_;
   Ogre::Vector3 location_;
 };

--- a/tesseract_rviz/include/tesseract_rviz/markers/arrow_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/arrow_marker.h
@@ -53,8 +53,8 @@ namespace tesseract_rviz
 class ArrowMarker : public MarkerBase
 {
 public:
-  using SharedPtr = std::shared_ptr<ArrowMarker>;
-  using ConstSharedPtr = std::shared_ptr<const ArrowMarker>;
+  using Ptr = std::shared_ptr<ArrowMarker>;
+  using ConstPtr = std::shared_ptr<const ArrowMarker>;
 
   ArrowMarker(const std::string& ns, const int id, rviz_common::DisplayContext* context, Ogre::SceneNode* parent_node);
 

--- a/tesseract_rviz/include/tesseract_rviz/markers/cube_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/cube_marker.h
@@ -32,7 +32,7 @@
 #include <string>
 #endif
 
-namespace rviz
+namespace rviz_rendering
 {
 class Shape;
 }
@@ -42,12 +42,12 @@ namespace tesseract_rviz
 class CubeMarker : public MarkerBase
 {
 public:
-  using Ptr = boost::shared_ptr<CubeMarker>;
-  using ConstPtr = boost::shared_ptr<const CubeMarker>;
+  using SharedPtr = std::shared_ptr<CubeMarker>;
+  using ConstSharedPtr = std::shared_ptr<const CubeMarker>;
 
   CubeMarker(const std::string& ns,
              const int id,
-             rviz::DisplayContext* context,
+             rviz_common::DisplayContext* context,
              Ogre::SceneNode* parent_node,
              float size = 1);
   ~CubeMarker() override;
@@ -63,7 +63,7 @@ public:
   std::set<Ogre::MaterialPtr> getMaterials() override;
 
 protected:
-  rviz::Shape* shape_;
+  rviz_rendering::Shape* shape_;
   Ogre::Vector3 scale_;
   float size_;
 };

--- a/tesseract_rviz/include/tesseract_rviz/markers/cube_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/cube_marker.h
@@ -42,8 +42,8 @@ namespace tesseract_rviz
 class CubeMarker : public MarkerBase
 {
 public:
-  using SharedPtr = std::shared_ptr<CubeMarker>;
-  using ConstSharedPtr = std::shared_ptr<const CubeMarker>;
+  using Ptr = std::shared_ptr<CubeMarker>;
+  using ConstPtr = std::shared_ptr<const CubeMarker>;
 
   CubeMarker(const std::string& ns,
              const int id,

--- a/tesseract_rviz/include/tesseract_rviz/markers/cylinder_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/cylinder_marker.h
@@ -32,7 +32,7 @@
 #include <string>
 #endif
 
-namespace rviz
+namespace rviz_rendering
 {
 class Shape;
 }
@@ -42,12 +42,12 @@ namespace tesseract_rviz
 class CylinderMarker : public MarkerBase
 {
 public:
-  using Ptr = boost::shared_ptr<CylinderMarker>;
-  using ConstPtr = boost::shared_ptr<const CylinderMarker>;
+  using SharedPtr = std::shared_ptr<CylinderMarker>;
+  using ConstSharedPtr = std::shared_ptr<const CylinderMarker>;
 
   CylinderMarker(const std::string& ns,
                  const int id,
-                 rviz::DisplayContext* context,
+                 rviz_common::DisplayContext* context,
                  Ogre::SceneNode* parent_node,
                  float radius = 1,
                  float height = 2);
@@ -67,7 +67,7 @@ public:
   std::set<Ogre::MaterialPtr> getMaterials() override;
 
 protected:
-  rviz::Shape* shape_;
+  rviz_rendering::Shape* shape_;
   Ogre::Vector3 scale_;
   float radius_;
   float height_;

--- a/tesseract_rviz/include/tesseract_rviz/markers/cylinder_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/cylinder_marker.h
@@ -42,8 +42,8 @@ namespace tesseract_rviz
 class CylinderMarker : public MarkerBase
 {
 public:
-  using SharedPtr = std::shared_ptr<CylinderMarker>;
-  using ConstSharedPtr = std::shared_ptr<const CylinderMarker>;
+  using Ptr = std::shared_ptr<CylinderMarker>;
+  using ConstPtr = std::shared_ptr<const CylinderMarker>;
 
   CylinderMarker(const std::string& ns,
                  const int id,

--- a/tesseract_rviz/include/tesseract_rviz/markers/marker_base.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/marker_base.h
@@ -29,23 +29,21 @@
 #ifndef TESSERACT_RVIZ_MARKERS_MARKER_BASE_H
 #define TESSERACT_RVIZ_MARKERS_MARKER_BASE_H
 
-#include "rviz/selection/forwards.h"
-#include "rviz/interactive_object.h"
+#include "rviz_common/interaction/forwards.hpp"
+#include "rviz_common/interactive_object.hpp"
 
 #ifndef Q_MOC_RUN
-#include <ros/time.h>
-#include <boost/shared_ptr.hpp>
 #endif
 
 namespace Ogre
 {
 class SceneNode;
-class Vector3;
+//class Vector3;
 class Quaternion;
 class Entity;
 }  // namespace Ogre
 
-namespace rviz
+namespace rviz_common
 {
 class DisplayContext;
 }
@@ -58,10 +56,10 @@ typedef std::pair<std::string, int32_t> MarkerID;
 class MarkerBase
 {
 public:
-  using Ptr = boost::shared_ptr<MarkerBase>;
-  using ConstPtr = boost::shared_ptr<const MarkerBase>;
+  using SharedPtr = std::shared_ptr<MarkerBase>;
+  using ConstSharedPtr = std::shared_ptr<const MarkerBase>;
 
-  MarkerBase(std::string ns, const int id, rviz::DisplayContext* context, Ogre::SceneNode* parent_node);
+  MarkerBase(const std::string& ns, const int id, rviz_common::DisplayContext* context, Ogre::SceneNode* parent_node);
   virtual ~MarkerBase();
 
   MarkerID getID() { return MarkerID(ns_, id_); }
@@ -74,7 +72,7 @@ public:
   }
 
   /** @brief Associate an InteractiveObject with this MarkerBase. */
-  void setInteractiveObject(rviz::InteractiveObjectWPtr object);
+  void setInteractiveObject(rviz_common::InteractiveObjectWPtr object);
 
   virtual void setPosition(const Ogre::Vector3& position);
   virtual void setOrientation(const Ogre::Quaternion& orientation);
@@ -95,11 +93,11 @@ protected:
 
   int id_;
 
-  rviz::DisplayContext* context_;
+  rviz_common::DisplayContext* context_;
 
   Ogre::SceneNode* scene_node_;
 
-  boost::shared_ptr<MarkerSelectionHandler> handler_;
+  std::shared_ptr<MarkerSelectionHandler> handler_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/markers/marker_base.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/marker_base.h
@@ -38,7 +38,6 @@
 namespace Ogre
 {
 class SceneNode;
-//class Vector3;
 class Quaternion;
 class Entity;
 }  // namespace Ogre
@@ -56,10 +55,10 @@ typedef std::pair<std::string, int32_t> MarkerID;
 class MarkerBase
 {
 public:
-  using SharedPtr = std::shared_ptr<MarkerBase>;
-  using ConstSharedPtr = std::shared_ptr<const MarkerBase>;
+  using Ptr = std::shared_ptr<MarkerBase>;
+  using ConstPtr = std::shared_ptr<const MarkerBase>;
 
-  MarkerBase(const std::string& ns, const int id, rviz_common::DisplayContext* context, Ogre::SceneNode* parent_node);
+  MarkerBase(std::string ns, const int id, rviz_common::DisplayContext* context, Ogre::SceneNode* parent_node);
   virtual ~MarkerBase();
 
   MarkerID getID() { return MarkerID(ns_, id_); }

--- a/tesseract_rviz/include/tesseract_rviz/markers/marker_selection_handler.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/marker_selection_handler.h
@@ -39,8 +39,8 @@ typedef std::pair<std::string, int32_t> MarkerID;
 class MarkerSelectionHandler : public rviz_common::interaction::SelectionHandler
 {
 public:
-  using SharedPtr = std::shared_ptr<MarkerSelectionHandler>;
-  using ConstSharedPtr = std::shared_ptr<const MarkerSelectionHandler>;
+  using Ptr = std::shared_ptr<MarkerSelectionHandler>;
+  using ConstPtr = std::shared_ptr<const MarkerSelectionHandler>;
 
   MarkerSelectionHandler(const MarkerBase* marker, MarkerID id, rviz_common::DisplayContext* context);
   virtual ~MarkerSelectionHandler();

--- a/tesseract_rviz/include/tesseract_rviz/markers/marker_selection_handler.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/marker_selection_handler.h
@@ -28,21 +28,21 @@
  */
 #ifndef TESSERACT_RVIZ_MARKERS_MARKER_SELECTION_HANDLER_H
 #define TESSERACT_RVIZ_MARKERS_MARKER_SELECTION_HANDLER_H
-#include "rviz/selection/forwards.h"
-#include "rviz/selection/selection_manager.h"
+#include "rviz_common/interaction/forwards.hpp"
+#include "rviz_common/interaction/selection_manager.hpp"
 
 namespace tesseract_rviz
 {
 class MarkerBase;
 typedef std::pair<std::string, int32_t> MarkerID;
 
-class MarkerSelectionHandler : public rviz::SelectionHandler
+class MarkerSelectionHandler : public rviz_common::interaction::SelectionHandler
 {
 public:
-  using Ptr = boost::shared_ptr<MarkerSelectionHandler>;
-  using ConstPtr = boost::shared_ptr<const MarkerSelectionHandler>;
+  using SharedPtr = std::shared_ptr<MarkerSelectionHandler>;
+  using ConstSharedPtr = std::shared_ptr<const MarkerSelectionHandler>;
 
-  MarkerSelectionHandler(const MarkerBase* marker, MarkerID id, rviz::DisplayContext* context);
+  MarkerSelectionHandler(const MarkerBase* marker, MarkerID id, rviz_common::DisplayContext* context);
   virtual ~MarkerSelectionHandler();
 
   virtual void setPosition(const Ogre::Vector3& position);

--- a/tesseract_rviz/include/tesseract_rviz/markers/sphere_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/sphere_marker.h
@@ -42,8 +42,8 @@ namespace tesseract_rviz
 class SphereMarker : public MarkerBase
 {
 public:
-  using SharedPtr = std::shared_ptr<SphereMarker>;
-  using ConstSharedPtr = std::shared_ptr<const SphereMarker>;
+  using Ptr = std::shared_ptr<SphereMarker>;
+  using ConstPtr = std::shared_ptr<const SphereMarker>;
 
   SphereMarker(const std::string& ns,
                const int id,

--- a/tesseract_rviz/include/tesseract_rviz/markers/sphere_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/sphere_marker.h
@@ -32,7 +32,7 @@
 #include <string>
 #endif
 
-namespace rviz
+namespace rviz_rendering
 {
 class Shape;
 }
@@ -42,12 +42,12 @@ namespace tesseract_rviz
 class SphereMarker : public MarkerBase
 {
 public:
-  using Ptr = boost::shared_ptr<SphereMarker>;
-  using ConstPtr = boost::shared_ptr<const SphereMarker>;
+  using SharedPtr = std::shared_ptr<SphereMarker>;
+  using ConstSharedPtr = std::shared_ptr<const SphereMarker>;
 
   SphereMarker(const std::string& ns,
                const int id,
-               rviz::DisplayContext* context,
+               rviz_common::DisplayContext* context,
                Ogre::SceneNode* parent_node,
                float radius = 1);
   ~SphereMarker() override;
@@ -63,7 +63,7 @@ public:
   std::set<Ogre::MaterialPtr> getMaterials() override;
 
 protected:
-  rviz::Shape* shape_;
+  rviz_rendering::Shape* shape_;
   Ogre::Vector3 scale_;
   float radius_;
 };

--- a/tesseract_rviz/include/tesseract_rviz/markers/text_view_facing_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/text_view_facing_marker.h
@@ -36,7 +36,7 @@ namespace Ogre
 class SceneNode;
 }
 
-namespace rviz
+namespace rviz_rendering
 {
 class MovableText;
 }
@@ -46,13 +46,13 @@ namespace tesseract_rviz
 class TextViewFacingMarker : public MarkerBase
 {
 public:
-  using Ptr = boost::shared_ptr<TextViewFacingMarker>;
-  using ConstPtr = boost::shared_ptr<const TextViewFacingMarker>;
+  using SharedPtr = std::shared_ptr<TextViewFacingMarker>;
+  using ConstSharedPtr = std::shared_ptr<const TextViewFacingMarker>;
 
   TextViewFacingMarker(const std::string& ns,
                        const int id,
                        const std::string& caption,
-                       rviz::DisplayContext* context,
+                       rviz_common::DisplayContext* context,
                        Ogre::SceneNode* parent_node);
 
   ~TextViewFacingMarker() override;
@@ -69,7 +69,7 @@ public:
   std::set<Ogre::MaterialPtr> getMaterials() override;
 
 protected:
-  rviz::MovableText* text_;
+  rviz_rendering::MovableText* text_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/markers/text_view_facing_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/text_view_facing_marker.h
@@ -46,8 +46,8 @@ namespace tesseract_rviz
 class TextViewFacingMarker : public MarkerBase
 {
 public:
-  using SharedPtr = std::shared_ptr<TextViewFacingMarker>;
-  using ConstSharedPtr = std::shared_ptr<const TextViewFacingMarker>;
+  using Ptr = std::shared_ptr<TextViewFacingMarker>;
+  using ConstPtr = std::shared_ptr<const TextViewFacingMarker>;
 
   TextViewFacingMarker(const std::string& ns,
                        const int id,

--- a/tesseract_rviz/include/tesseract_rviz/markers/triangle_list_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/triangle_list_marker.h
@@ -54,8 +54,8 @@ namespace tesseract_rviz
 class TriangleListMarker : public MarkerBase
 {
 public:
-  using SharedPtr = std::shared_ptr<TriangleListMarker>;
-  using ConstSharedPtr = std::shared_ptr<const TriangleListMarker>;
+  using Ptr = std::shared_ptr<TriangleListMarker>;
+  using ConstPtr = std::shared_ptr<const TriangleListMarker>;
 
   TriangleListMarker(const std::string& ns,
                      const int id,

--- a/tesseract_rviz/include/tesseract_rviz/markers/triangle_list_marker.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/triangle_list_marker.h
@@ -40,9 +40,12 @@ namespace Ogre
 class SceneNode;
 }
 
-namespace rviz
+namespace rviz_rendering
 {
 class Arrow;
+}
+
+namespace rviz_common {
 class DisplayContext;
 }  // namespace rviz
 
@@ -51,12 +54,12 @@ namespace tesseract_rviz
 class TriangleListMarker : public MarkerBase
 {
 public:
-  using Ptr = boost::shared_ptr<TriangleListMarker>;
-  using ConstPtr = boost::shared_ptr<const TriangleListMarker>;
+  using SharedPtr = std::shared_ptr<TriangleListMarker>;
+  using ConstSharedPtr = std::shared_ptr<const TriangleListMarker>;
 
   TriangleListMarker(const std::string& ns,
                      const int id,
-                     rviz::DisplayContext* context,
+                     rviz_common::DisplayContext* context,
                      Ogre::SceneNode* parent_node,
                      const Ogre::ColourValue color,
                      const std::vector<Ogre::Vector3>& points,

--- a/tesseract_rviz/include/tesseract_rviz/markers/utils.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/utils.h
@@ -36,11 +36,11 @@ namespace Ogre
 {
 class SceneNode;
 class Quaternion;
-class Vector3;
+//class Vector3;
 class ColourValue;
 }  // namespace Ogre
 
-namespace rviz
+namespace rviz_common
 {
 class DisplayContext;
 }

--- a/tesseract_rviz/include/tesseract_rviz/markers/utils.h
+++ b/tesseract_rviz/include/tesseract_rviz/markers/utils.h
@@ -36,7 +36,6 @@ namespace Ogre
 {
 class SceneNode;
 class Quaternion;
-//class Vector3;
 class ColourValue;
 }  // namespace Ogre
 

--- a/tesseract_rviz/include/tesseract_rviz/property/button_property.h
+++ b/tesseract_rviz/include/tesseract_rviz/property/button_property.h
@@ -44,6 +44,8 @@ public:
                  const char* changed_slot = nullptr,
                  QObject* receiver = nullptr);
 
+  virtual ~ButtonProperty() = default;
+
   QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option) override;
 
   bool paint(QPainter* painter, const QStyleOptionViewItem& option) const override;

--- a/tesseract_rviz/include/tesseract_rviz/property/button_property.h
+++ b/tesseract_rviz/include/tesseract_rviz/property/button_property.h
@@ -29,18 +29,18 @@
 #include <QStringList>
 #include <QPushButton>
 
-#include "rviz/properties/property.h"
+#include "rviz_common/properties/property.hpp"
 
 namespace tesseract_rviz
 {
-class ButtonProperty : public rviz::Property
+class ButtonProperty : public rviz_common::properties::Property
 {
   Q_OBJECT
 public:
   ButtonProperty(const QString& name = QString(),
                  const QString& default_value = QString(),
                  const QString& description = QString(),
-                 rviz::Property* parent = nullptr,
+                 rviz_common::properties::Property* parent = nullptr,
                  const char* changed_slot = nullptr,
                  QObject* receiver = nullptr);
 

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/environment_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/environment_widget.h
@@ -3,24 +3,24 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <rviz/display.h>
+#include <rviz_common/display.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #ifndef Q_MOC_RUN
 
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <ros/ros.h>
-#include <ros/service_server.h>
-#include <ros/subscriber.h>
-#include <tesseract_monitoring/environment_monitor.h>
-#include <std_msgs/ColorRGBA.h>
-#include <tesseract_environment/environment.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tesseract_msgs/srv/modify_environment.hpp>
+#include <tesseract_msgs/srv/get_environment_changes.hpp>
+#include <tesseract_msgs/msg/tesseract_state.hpp>
+#include <std_msgs/msg/color_rgba.hpp>
+#include <tesseract/tesseract.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #endif
 #include <tesseract_rviz/render_tools/visualization_widget.h>
 
-namespace rviz
+namespace rviz_common::properties
 {
 class Property;
 class RosTopicProperty;
@@ -35,18 +35,19 @@ class EnvironmentWidget : public QObject
   Q_OBJECT
 
 public:
-  using Ptr = std::shared_ptr<EnvironmentWidget>;
-  using ConstPtr = std::shared_ptr<const EnvironmentWidget>;
+  using SharedPtr = std::shared_ptr<EnvironmentWidget>;
+  using ConstSharedPtr = std::shared_ptr<const EnvironmentWidget>;
 
-  EnvironmentWidget(rviz::Property* widget, rviz::Display* display, const std::string& widget_ns = std::string());
+  EnvironmentWidget(rviz_common::properties::Property* widget, rviz_common::Display* display, const std::string& widget_ns = std::string());
 
   virtual ~EnvironmentWidget();
 
-  void onInitialize(VisualizationWidget::Ptr visualization,
-                    tesseract_environment::Environment::Ptr env,
-                    rviz::DisplayContext* context,
-                    const ros::NodeHandle& update_nh,
-                    bool update_state);
+  void onInitialize(VisualizationWidget::SharedPtr visualization,
+                    tesseract::Tesseract::Ptr tesseract,
+                    rviz_common::DisplayContext* context,
+                    rclcpp::Node::SharedPtr update_nh,
+                    bool update_state,
+                    QString tesseract_state_topic = "");
 
   void onEnable();
   void onDisable();
@@ -57,9 +58,10 @@ public:
   int getId() const { return environment_widget_id_; }
 
 private Q_SLOTS:
+  void changedURDFDescription();
+  void changedEnvironmentNamespace();
   void changedRootLinkName();
-  void changedDisplayMode();
-  void changedDisplayModeString();
+  void changedTesseractStateTopic();
   void changedURDFSceneAlpha();
   void changedEnableLinkHighlight();
   void changedEnableVisualVisible();
@@ -67,37 +69,55 @@ private Q_SLOTS:
   void changedAllLinks();
 
 protected:
-  rviz::Property* widget_;
-  rviz::Display* display_;
-  VisualizationWidget::Ptr visualization_;
-  tesseract_environment::Environment::Ptr env_;
-  ros::NodeHandle nh_;
-  std::unique_ptr<tesseract_monitoring::EnvironmentMonitor> monitor_;
-  int revision_{ 0 }; /**< The current revision of the visualization environment */
+  rviz_common::properties::Property* widget_;
+  rviz_common::Display* display_;
+  VisualizationWidget::SharedPtr visualization_;
+  tesseract::Tesseract::Ptr tesseract_;
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Subscription<tesseract_msgs::msg::TesseractState>::SharedPtr tesseract_state_subscriber_; /**< @brief subscriber for getting environment updates */
+  rclcpp::Service<tesseract_msgs::srv::ModifyEnvironment>::SharedPtr modify_environment_server_;      /**< @brief host a service for modifying the environment */
+  rclcpp::Service<tesseract_msgs::srv::GetEnvironmentChanges>::SharedPtr get_environment_changes_server_; /**< @brief host a service for getting the environment changes */
   bool update_required_;
   bool update_state_;    /**< @brief Update visualization current state from environment message */
   bool load_tesseract_;  // for delayed initialization
-  std::map<std::string, std_msgs::ColorRGBA> highlights_;
-  std::chrono::high_resolution_clock::duration state_timestamp_{
-    std::chrono::high_resolution_clock::now().time_since_epoch()
-  };
+  std::map<std::string, std_msgs::msg::ColorRGBA> highlights_;
 
   void loadEnvironment();
 
+  /** @brief Set the scene node's position, given the target frame and the planning frame */
+  //  void calculateOffsetPosition();
+
+  //  void setLinkColor(const tesseract_msgs::TesseractState::_object_colors_type& link_colors);
+  //  void setLinkColor(Robot* robot, const std::string& link_name, const QColor& color);
+  //  void unsetLinkColor(Robot* robot, const std::string& link_name);
+
+  /** @brief Callback for new tesseract state message */
+  void newTesseractStateCallback(const tesseract_msgs::msg::TesseractState::ConstSharedPtr state);
+
+  /** @brief Callback for modifying the environment via service request */
+  bool modifyEnvironmentCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+      tesseract_msgs::srv::ModifyEnvironment::Request::SharedPtr req,
+                                 tesseract_msgs::srv::ModifyEnvironment::Response::SharedPtr res);
+
+  /** @brief Callback for get the environment changes via service request */
+  bool getEnvironmentChangesCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+                                     tesseract_msgs::srv::GetEnvironmentChanges::Request::SharedPtr req,
+                                     tesseract_msgs::srv::GetEnvironmentChanges::Response::SharedPtr res);
+
   /** @brief Apply a list of commands to the environment. This used by both services and topics for updating environment
    * visualization */
-  bool applyEnvironmentCommands(const tesseract_environment::Command& command);
+  bool applyEnvironmentCommands(const std::vector<tesseract_msgs::msg::EnvironmentCommand>& commands);
 
-  rviz::Property* main_property_;
-  rviz::EnumProperty* display_mode_property_;
-  rviz::StringProperty* display_mode_string_property_;
-  rviz::StringProperty* environment_namespace_property_;
-  rviz::StringProperty* root_link_name_property_;
-  rviz::FloatProperty* alpha_property_;
-  rviz::BoolProperty* enable_link_highlight_;
-  rviz::BoolProperty* enable_visual_visible_;
-  rviz::BoolProperty* enable_collision_visible_;
-  rviz::BoolProperty* show_all_links_;
+  rviz_common::properties::Property* main_property_;
+  rviz_common::properties::StringProperty* urdf_description_property_;
+  rviz_common::properties::StringProperty* environment_namespace_property_;
+  rviz_common::properties::RosTopicProperty* tesseract_state_topic_property_;
+  rviz_common::properties::StringProperty* root_link_name_property_;
+  rviz_common::properties::FloatProperty* alpha_property_;
+  rviz_common::properties::BoolProperty* enable_link_highlight_;
+  rviz_common::properties::BoolProperty* enable_visual_visible_;
+  rviz_common::properties::BoolProperty* enable_collision_visible_;
+  rviz_common::properties::BoolProperty* show_all_links_;
 
 private:
   /** @brief Keeps track of how many EnvironmentWidgets have been created for the default namespace */

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/environment_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/environment_widget.h
@@ -2,22 +2,19 @@
 #define TESSERACT_RVIZ_ENVIRONMENT_MONITORING_H
 
 #include <tesseract_common/macros.h>
-TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <rclcpp/rclcpp.hpp>
 #include <rviz_common/display.hpp>
-TESSERACT_COMMON_IGNORE_WARNINGS_POP
+#include <tesseract_monitoring/environment_monitor.h>
+#include <std_msgs/msg/color_rgba.hpp>
 
 #ifndef Q_MOC_RUN
 
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <rclcpp/rclcpp.hpp>
-#include <tesseract_msgs/srv/modify_environment.hpp>
-#include <tesseract_msgs/srv/get_environment_changes.hpp>
-#include <tesseract_msgs/msg/tesseract_state.hpp>
-#include <std_msgs/msg/color_rgba.hpp>
-#include <tesseract/tesseract.h>
+#include <tesseract_environment/environment.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #endif
+
 #include <tesseract_rviz/render_tools/visualization_widget.h>
 
 namespace rviz_common::properties
@@ -35,19 +32,18 @@ class EnvironmentWidget : public QObject
   Q_OBJECT
 
 public:
-  using SharedPtr = std::shared_ptr<EnvironmentWidget>;
-  using ConstSharedPtr = std::shared_ptr<const EnvironmentWidget>;
+  using Ptr = std::shared_ptr<EnvironmentWidget>;
+  using ConstPtr = std::shared_ptr<const EnvironmentWidget>;
 
   EnvironmentWidget(rviz_common::properties::Property* widget, rviz_common::Display* display, const std::string& widget_ns = std::string());
 
   virtual ~EnvironmentWidget();
 
-  void onInitialize(VisualizationWidget::SharedPtr visualization,
-                    tesseract::Tesseract::Ptr tesseract,
+  void onInitialize(VisualizationWidget::Ptr visualization,
+                    tesseract_environment::Environment::Ptr env,
                     rviz_common::DisplayContext* context,
-                    rclcpp::Node::SharedPtr update_nh,
-                    bool update_state,
-                    QString tesseract_state_topic = "");
+                    rclcpp::Node::SharedPtr update_node,
+                    bool update_state);
 
   void onEnable();
   void onDisable();
@@ -59,9 +55,9 @@ public:
 
 private Q_SLOTS:
   void changedURDFDescription();
-  void changedEnvironmentNamespace();
   void changedRootLinkName();
-  void changedTesseractStateTopic();
+  void changedDisplayMode();
+  void changedDisplayModeString();
   void changedURDFSceneAlpha();
   void changedEnableLinkHighlight();
   void changedEnableVisualVisible();
@@ -71,16 +67,19 @@ private Q_SLOTS:
 protected:
   rviz_common::properties::Property* widget_;
   rviz_common::Display* display_;
-  VisualizationWidget::SharedPtr visualization_;
-  tesseract::Tesseract::Ptr tesseract_;
+  VisualizationWidget::Ptr visualization_;
+  tesseract_environment::Environment::Ptr env_;
   rclcpp::Node::SharedPtr node_;
-  rclcpp::Subscription<tesseract_msgs::msg::TesseractState>::SharedPtr tesseract_state_subscriber_; /**< @brief subscriber for getting environment updates */
-  rclcpp::Service<tesseract_msgs::srv::ModifyEnvironment>::SharedPtr modify_environment_server_;      /**< @brief host a service for modifying the environment */
-  rclcpp::Service<tesseract_msgs::srv::GetEnvironmentChanges>::SharedPtr get_environment_changes_server_; /**< @brief host a service for getting the environment changes */
+  rclcpp::SubscriptionBase::SharedPtr robot_description_sub_;
+  std::unique_ptr<tesseract_monitoring::EnvironmentMonitor> monitor_;
+  int revision_{ 0 }; /**< The current revision of the visualization environment */
   bool update_required_;
   bool update_state_;    /**< @brief Update visualization current state from environment message */
   bool load_tesseract_;  // for delayed initialization
   std::map<std::string, std_msgs::msg::ColorRGBA> highlights_;
+  std::chrono::high_resolution_clock::duration state_timestamp_{
+    std::chrono::high_resolution_clock::now().time_since_epoch()
+  };
 
   void loadEnvironment();
 
@@ -91,27 +90,25 @@ protected:
   //  void setLinkColor(Robot* robot, const std::string& link_name, const QColor& color);
   //  void unsetLinkColor(Robot* robot, const std::string& link_name);
 
-  /** @brief Callback for new tesseract state message */
-  void newTesseractStateCallback(const tesseract_msgs::msg::TesseractState::ConstSharedPtr state);
-
   /** @brief Callback for modifying the environment via service request */
-  bool modifyEnvironmentCallback(const std::shared_ptr<rmw_request_id_t> request_header,
-      tesseract_msgs::srv::ModifyEnvironment::Request::SharedPtr req,
-                                 tesseract_msgs::srv::ModifyEnvironment::Response::SharedPtr res);
+  //void modifyEnvironmentCallback(
+  //  tesseract_msgs::srv::ModifyEnvironment::Request::SharedPtr req,
+  //  tesseract_msgs::srv::ModifyEnvironment::Response::SharedPtr res);
 
   /** @brief Callback for get the environment changes via service request */
-  bool getEnvironmentChangesCallback(const std::shared_ptr<rmw_request_id_t> request_header,
-                                     tesseract_msgs::srv::GetEnvironmentChanges::Request::SharedPtr req,
-                                     tesseract_msgs::srv::GetEnvironmentChanges::Response::SharedPtr res);
+  //void getEnvironmentChangesCallback(
+  //  tesseract_msgs::srv::GetEnvironmentChanges::Request::SharedPtr req,
+  //  tesseract_msgs::srv::GetEnvironmentChanges::Response::SharedPtr res);
 
   /** @brief Apply a list of commands to the environment. This used by both services and topics for updating environment
    * visualization */
-  bool applyEnvironmentCommands(const std::vector<tesseract_msgs::msg::EnvironmentCommand>& commands);
+  bool applyEnvironmentCommands(const tesseract_environment::Command& command);
 
   rviz_common::properties::Property* main_property_;
+  rviz_common::properties::EnumProperty* display_mode_property_;
+  rviz_common::properties::StringProperty* display_mode_string_property_;
   rviz_common::properties::StringProperty* urdf_description_property_;
   rviz_common::properties::StringProperty* environment_namespace_property_;
-  rviz_common::properties::RosTopicProperty* tesseract_state_topic_property_;
   rviz_common::properties::StringProperty* root_link_name_property_;
   rviz_common::properties::FloatProperty* alpha_property_;
   rviz_common::properties::BoolProperty* enable_link_highlight_;

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/joint_state_monitor_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/joint_state_monitor_widget.h
@@ -3,21 +3,20 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <rviz/display.h>
+#include <rviz_common/display.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #ifndef Q_MOC_RUN
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <ros/ros.h>
-#include <ros/service_server.h>
-#include <sensor_msgs/JointState.h>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
-#include <tesseract_environment/environment.h>
+#include <tesseract/tesseract.h>
 #endif
 
 #include <tesseract_rviz/render_tools/visualization_widget.h>
 
-namespace rviz
+namespace rviz_common::properties
 {
 class Property;
 class RosTopicProperty;
@@ -30,17 +29,17 @@ class JointStateMonitorWidget : public QObject
   Q_OBJECT
 
 public:
-  using Ptr = std::shared_ptr<JointStateMonitorWidget>;
-  using ConstPtr = std::shared_ptr<const JointStateMonitorWidget>;
+  using SharedPtr = std::shared_ptr<JointStateMonitorWidget>;
+  using ConstSharedPtr = std::shared_ptr<const JointStateMonitorWidget>;
 
-  JointStateMonitorWidget(rviz::Property* widget, rviz::Display* display);
+  JointStateMonitorWidget(rviz_common::properties::Property* widget, rviz_common::Display* display);
 
   virtual ~JointStateMonitorWidget();
 
-  void onInitialize(VisualizationWidget::Ptr visualization,
-                    tesseract_environment::Environment::Ptr env,
-                    rviz::DisplayContext* context,
-                    const ros::NodeHandle& update_nh);
+  void onInitialize(VisualizationWidget::SharedPtr visualization,
+                    tesseract::Tesseract::Ptr tesseract,
+                    rviz_common::DisplayContext* context,
+                    rclcpp::Node::SharedPtr update_node);
 
   void onEnable();
   void onDisable();
@@ -51,20 +50,20 @@ private Q_SLOTS:
   void changedJointStateTopic();
 
 protected:
-  rviz::Property* widget_;
-  rviz::Display* display_;
-  VisualizationWidget::Ptr visualization_;
-  tesseract_environment::Environment::Ptr env_;
-  ros::NodeHandle nh_;
-  ros::Subscriber joint_state_subscriber_;
+  rviz_common::properties::Property* widget_;
+  rviz_common::Display* display_;
+  VisualizationWidget::SharedPtr visualization_;
+  tesseract::Tesseract::Ptr tesseract_;
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_subscriber_;
   bool update_required_;
 
-  rviz::Property* main_property_;
-  rviz::RosTopicProperty* joint_state_topic_property_;
+  rviz_common::properties::Property* main_property_;
+  rviz_common::properties::RosTopicProperty* joint_state_topic_property_;
 
-  void newJointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state_msg);
+  void newJointStateCallback(const sensor_msgs::msg::JointState::ConstSharedPtr joint_state);
 
-  bool isUpdateRequired(const sensor_msgs::JointState& joint_state);
+  bool isUpdateRequired(const sensor_msgs::msg::JointState& joint_state);
 };
 }  // namespace tesseract_rviz
 #endif  // TESSERACT_RVIZ_STATE_MONITORING_H

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/joint_state_monitor_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/joint_state_monitor_widget.h
@@ -11,7 +11,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
-#include <tesseract/tesseract.h>
+#include <tesseract_environment/environment.h>
 #endif
 
 #include <tesseract_rviz/render_tools/visualization_widget.h>
@@ -29,15 +29,15 @@ class JointStateMonitorWidget : public QObject
   Q_OBJECT
 
 public:
-  using SharedPtr = std::shared_ptr<JointStateMonitorWidget>;
-  using ConstSharedPtr = std::shared_ptr<const JointStateMonitorWidget>;
+  using Ptr = std::shared_ptr<JointStateMonitorWidget>;
+  using ConstPtr = std::shared_ptr<const JointStateMonitorWidget>;
 
   JointStateMonitorWidget(rviz_common::properties::Property* widget, rviz_common::Display* display);
 
   virtual ~JointStateMonitorWidget();
 
-  void onInitialize(VisualizationWidget::SharedPtr visualization,
-                    tesseract::Tesseract::Ptr tesseract,
+  void onInitialize(VisualizationWidget::Ptr visualization,
+                    tesseract_environment::Environment::Ptr env,
                     rviz_common::DisplayContext* context,
                     rclcpp::Node::SharedPtr update_node);
 
@@ -52,8 +52,8 @@ private Q_SLOTS:
 protected:
   rviz_common::properties::Property* widget_;
   rviz_common::Display* display_;
-  VisualizationWidget::SharedPtr visualization_;
-  tesseract::Tesseract::Ptr tesseract_;
+  VisualizationWidget::Ptr visualization_;
+  tesseract_environment::Environment::Ptr env_;
   rclcpp::Node::SharedPtr node_;
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_subscriber_;
   bool update_required_;

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/joint_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/joint_widget.h
@@ -45,8 +45,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <tesseract_scene_graph/joint.h>
 #endif
 
-#include <rviz/ogre_helpers/object.h>
-#include <rviz/selection/forwards.h>
+#include <rviz_rendering/objects/object.hpp>
+#include <rviz_common/interaction/forwards.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace Ogre
@@ -55,18 +55,25 @@ class SceneManager;
 class Entity;
 class SubEntity;
 class SceneNode;
-class Vector3;
+//class Vector3;
 class Quaternion;
 class Any;
 class RibbonTrail;
 }  // namespace Ogre
 
-namespace rviz
+namespace rviz_rendering
 {
 class Shape;
 class Arrow;
 class Axes;
+}
+
+namespace rviz_common {
 class DisplayContext;
+}
+
+namespace rviz_common::properties
+{
 class FloatProperty;
 class Property;
 class BoolProperty;
@@ -98,12 +105,12 @@ public:
   const std::string& getParentLinkName() const { return parent_link_name_; }
 
   const std::string& getChildLinkName() const { return child_link_name_; }
-  const rviz::Property* getJointProperty() const { return joint_property_; }
-  rviz::Property* getJointProperty() { return joint_property_; }
+  const rviz_common::properties::Property* getJointProperty() const { return joint_property_; }
+  rviz_common::properties::Property* getJointProperty() { return joint_property_; }
   void hideSubProperties(bool hide);
 
   // Remove joint_property_ from its old parent and add to new_parent.  If new_parent==nullptr then leav unparented.
-  void setParentProperty(rviz::Property* new_parent);
+  void setParentProperty(rviz_common::properties::Property* new_parent);
 
   void setTransforms(const Ogre::Vector3& parent_link_position, const Ogre::Quaternion& parent_link_orientation);
   Ogre::Vector3 getPosition();
@@ -148,7 +155,7 @@ private:
                          bool recursive) const;           // True: all descendant links.  False: just single child link.
 
   // set the value of the enable checkbox without touching child joints/links
-  void setJointCheckbox(const QVariant& val);
+  void setJointCheckbox(QVariant val);
 
 protected:
   VisualizationWidget* env_;
@@ -157,17 +164,17 @@ protected:
   std::string child_link_name_;
 
   // properties
-  rviz::Property* joint_property_;
-  rviz::Property* details_;
-  rviz::VectorProperty* position_property_;
-  rviz::QuaternionProperty* orientation_property_;
-  rviz::Property* axes_property_;
+  rviz_common::properties::Property* joint_property_;
+  rviz_common::properties::Property* details_;
+  rviz_common::properties::VectorProperty* position_property_;
+  rviz_common::properties::QuaternionProperty* orientation_property_;
+  rviz_common::properties::Property* axes_property_;
   // The joint axis if any, as opposed to the frame in which the joint exists above
-  rviz::VectorProperty* axis_property_;
-  rviz::Property* show_axis_property_;
-  rviz::StringProperty* type_property_;
-  rviz::FloatProperty* lower_limit_property_;
-  rviz::FloatProperty* upper_limit_property_;
+  rviz_common::properties::VectorProperty* axis_property_;
+  rviz_common::properties::Property* show_axis_property_;
+  rviz_common::properties::StringProperty* type_property_;
+  rviz_common::properties::FloatProperty* lower_limit_property_;
+  rviz_common::properties::FloatProperty* upper_limit_property_;
 
 private:
   Ogre::Vector3 joint_origin_pos_;
@@ -176,8 +183,8 @@ private:
 
   bool doing_set_checkbox_;  // prevents updateChildVisibility() from  touching children
 
-  std::unique_ptr<rviz::Axes> axes_;
-  std::unique_ptr<rviz::Arrow> axis_;
+  rviz_rendering::Axes* axes_;
+  rviz_rendering::Arrow* axis_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/joint_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/joint_widget.h
@@ -55,7 +55,6 @@ class SceneManager;
 class Entity;
 class SubEntity;
 class SceneNode;
-//class Vector3;
 class Quaternion;
 class Any;
 class RibbonTrail;
@@ -155,7 +154,7 @@ private:
                          bool recursive) const;           // True: all descendant links.  False: just single child link.
 
   // set the value of the enable checkbox without touching child joints/links
-  void setJointCheckbox(QVariant val);
+  void setJointCheckbox(const QVariant& val);
 
 protected:
   VisualizationWidget* env_;
@@ -183,8 +182,8 @@ private:
 
   bool doing_set_checkbox_;  // prevents updateChildVisibility() from  touching children
 
-  rviz_rendering::Axes* axes_;
-  rviz_rendering::Arrow* axis_;
+  std::unique_ptr<rviz_rendering::Axes> axes_;
+  std::unique_ptr<rviz_rendering::Arrow> axis_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/link_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/link_widget.h
@@ -67,7 +67,6 @@ class SceneManager;
 class Entity;
 class SubEntity;
 class SceneNode;
-//class Vector3;
 class Quaternion;
 class Any;
 class RibbonTrail;
@@ -154,12 +153,21 @@ public:
 
   /**
    * @brief Set trajectory for the link
+   * @details With large trajectories maintaining the scene nodes is expensive if not being used.
+   * This method no longer creates the scene nodes and just stores the trajectory.
+   * The showTrajectory will create the scene nodes and clearTrajectory destroys them.
    * @param trajectory
    */
-  virtual void setTrajectory(const std::vector<Eigen::Isometry3d>& trajectory);
+  virtual void setTrajectory(const tesseract_common::VectorIsometry3d& trajectory);
+
+  /** @brief Show trajectory by creating visualization for the trajectory */
+  virtual void showTrajectory();
+
+  /** @brief Remove/destroy visual scene nodes for the trajectory */
+  virtual void clearTrajectory();
 
   /** @brief Hide trajectory */
-  virtual void clearTrajectory();
+  virtual void hideTrajectory();
 
   // This is usefule when wanting to simulate the trajectory
   virtual void showTrajectoryWaypointOnly(int waypoint);
@@ -199,6 +207,7 @@ public:
   Ogre::Vector3 getPosition();
   Ogre::Quaternion getOrientation();
 
+  void setVisibleEnabled(bool enabled);
   void setCollisionEnabled(bool enabled);
   void addAllowedCollision(const std::string& link_name, const std::string& reason);
   void removeAllowedCollision(const std::string& link_name);
@@ -250,7 +259,7 @@ private:
   void createCollision(const tesseract_scene_graph::Link& link);
 
   void createSelection();
-  Ogre::MaterialPtr getMaterialForLink(const tesseract_scene_graph::Link& link, const std::string material_name = "");
+  Ogre::MaterialPtr getMaterialForLink(const tesseract_scene_graph::Link& link, const std::string& material_name = "");
 
   void setOctomapColor(double z_pos, double min_z, double max_z, double color_factor, rviz_rendering::PointCloud::Point* point);
 
@@ -282,6 +291,7 @@ private:
   M_SubEntityToMaterial materials_;
   Ogre::MaterialPtr default_material_;
   std::string default_material_name_;
+  tesseract_common::VectorIsometry3d trajectory_;
   std::map<std::string, rviz_common::properties::StringProperty*> acm_;
 
   std::vector<Ogre::Entity*> visual_current_meshes_;     ///< The entities representing the visual mesh of this link (if
@@ -315,6 +325,7 @@ private:
     rviz_rendering::PointCloud* point_cloud;
     std::vector<rviz_rendering::PointCloud::Point> points;
     float size;
+    tesseract_geometry::Octree::SubType shape_type;
 
     rviz_rendering::PointCloud* clone();
   };
@@ -359,7 +370,7 @@ private:
 
   Ogre::RibbonTrail* trail_;
 
-  rviz_rendering::Axes* axes_;
+  std::unique_ptr<rviz_rendering::Axes> axes_;
 
   float material_alpha_;  ///< If material is not a texture, this saves the alpha value set in the URDF, otherwise is
                           /// 1.0.

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/link_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/link_widget.h
@@ -50,9 +50,14 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <tesseract_scene_graph/link.h>
 #endif
 
-#include <rviz/ogre_helpers/object.h>
-#include <rviz/ogre_helpers/point_cloud.h>
-#include <rviz/selection/forwards.h>
+#include <rviz_rendering/objects/object.hpp>
+#include <rviz_rendering/objects/point_cloud.hpp>
+#include <rviz_rendering/objects/axes.hpp>
+#include <rviz_common/interaction/forwards.hpp>
+#include <rviz_common/properties/property.hpp>
+#include <rviz_common/properties/float_property.hpp>
+#include <rviz_common/properties/vector_property.hpp>
+#include <rviz_common/properties/quaternion_property.hpp>
 
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
@@ -62,17 +67,25 @@ class SceneManager;
 class Entity;
 class SubEntity;
 class SceneNode;
-class Vector3;
+//class Vector3;
 class Quaternion;
 class Any;
 class RibbonTrail;
 }  // namespace Ogre
 
-namespace rviz
+
+namespace rviz_common
 {
+class DisplayContext;
+}
+
+namespace rviz_rendering {
 class Shape;
 class Axes;
-class DisplayContext;
+}
+
+namespace rviz_common::properties
+{
 class FloatProperty;
 class Property;
 class BoolProperty;
@@ -80,6 +93,7 @@ class QuaternionProperty;
 class VectorProperty;
 class StringProperty;
 }  // namespace rviz
+
 
 namespace octomap
 {
@@ -140,21 +154,12 @@ public:
 
   /**
    * @brief Set trajectory for the link
-   * @details With large trajectories maintaining the scene nodes is expensive if not being used.
-   * This method no longer creates the scene nodes and just stores the trajectory.
-   * The showTrajectory will create the scene nodes and clearTrajectory destroys them.
    * @param trajectory
    */
-  virtual void setTrajectory(const tesseract_common::VectorIsometry3d& trajectory);
-
-  /** @brief Show trajectory by creating visualization for the trajectory */
-  virtual void showTrajectory();
-
-  /** @brief Remove/destroy visual scene nodes for the trajectory */
-  virtual void clearTrajectory();
+  virtual void setTrajectory(const std::vector<Eigen::Isometry3d>& trajectory);
 
   /** @brief Hide trajectory */
-  virtual void hideTrajectory();
+  virtual void clearTrajectory();
 
   // This is usefule when wanting to simulate the trajectory
   virtual void showTrajectoryWaypointOnly(int waypoint);
@@ -162,7 +167,7 @@ public:
   // access
   const std::string& getName() const { return name_; }
 
-  rviz::Property* getLinkProperty() const { return link_property_; }
+  rviz_common::properties::Property* getLinkProperty() const { return link_property_; }
 
   Ogre::SceneNode* getCurrentVisualNode() const { return visual_current_node_; }
   Ogre::SceneNode* getCurrentCollisionNode() const { return collision_current_node_; }
@@ -175,7 +180,7 @@ public:
 
   VisualizationWidget* getEnvVisualization() const { return env_; }
   // Remove link_property_ from its old parent and add to new_parent.  If new_parent==nullptr then leav unparented.
-  void setParentProperty(rviz::Property* new_parent);
+  void setParentProperty(rviz_common::properties::Property* new_parent);
 
   // hide or show all sub properties (hide to make tree easier to see)
   virtual void hideSubProperties(bool hide);
@@ -194,7 +199,6 @@ public:
   Ogre::Vector3 getPosition();
   Ogre::Quaternion getOrientation();
 
-  void setVisibleEnabled(bool enabled);
   void setCollisionEnabled(bool enabled);
   void addAllowedCollision(const std::string& link_name, const std::string& reason);
   void removeAllowedCollision(const std::string& link_name);
@@ -246,40 +250,39 @@ private:
   void createCollision(const tesseract_scene_graph::Link& link);
 
   void createSelection();
-  Ogre::MaterialPtr getMaterialForLink(const tesseract_scene_graph::Link& link, const std::string& material_name = "");
+  Ogre::MaterialPtr getMaterialForLink(const tesseract_scene_graph::Link& link, const std::string material_name = "");
 
-  void setOctomapColor(double z_pos, double min_z, double max_z, double color_factor, rviz::PointCloud::Point* point);
+  void setOctomapColor(double z_pos, double min_z, double max_z, double color_factor, rviz_rendering::PointCloud::Point* point);
 
   void clone(Ogre::SceneNode* scene_node,
              Ogre::SceneNode* cloned_scene_node,
              std::vector<Ogre::Entity*>& meshes,
-             std::vector<rviz::PointCloud*>& octrees);
+             std::vector<rviz_rendering::PointCloud*>& octrees);
 
 protected:
   VisualizationWidget* env_;
   Ogre::SceneManager* scene_manager_;
-  rviz::DisplayContext* context_;
+  rviz_common::DisplayContext* context_;
 
   std::string name_;  ///< Name of this link
 
   // properties
-  rviz::Property* link_property_;
-  rviz::Property* details_;
-  rviz::VectorProperty* position_property_;
-  rviz::QuaternionProperty* orientation_property_;
-  rviz::Property* trail_property_;
-  rviz::Property* axes_property_;
-  rviz::FloatProperty* alpha_property_;
-  rviz::StringProperty* collision_enabled_property_;
-  rviz::Property* allowed_collision_matrix_property_;
-  std::map<std::string, rviz::StringProperty*> acm_;
+  rviz_common::properties::Property* link_property_;
+  rviz_common::properties::Property* details_;
+  rviz_common::properties::VectorProperty* position_property_;
+  rviz_common::properties::QuaternionProperty* orientation_property_;
+  rviz_common::properties::Property* trail_property_;
+  rviz_common::properties::Property* axes_property_;
+  rviz_common::properties::FloatProperty* alpha_property_;
+  rviz_common::properties::StringProperty* collision_enabled_property_;
+  rviz_common::properties::Property* allowed_collision_matrix_property_;
 
 private:
   typedef std::map<Ogre::SubEntity*, Ogre::MaterialPtr> M_SubEntityToMaterial;
   M_SubEntityToMaterial materials_;
   Ogre::MaterialPtr default_material_;
   std::string default_material_name_;
-  tesseract_common::VectorIsometry3d trajectory_;
+  std::map<std::string, rviz_common::properties::StringProperty*> acm_;
 
   std::vector<Ogre::Entity*> visual_current_meshes_;     ///< The entities representing the visual mesh of this link (if
                                                          ///< they
@@ -309,12 +312,11 @@ private:
 
   struct OctreeDataContainer
   {
-    rviz::PointCloud* point_cloud;
-    std::vector<rviz::PointCloud::Point> points;
+    rviz_rendering::PointCloud* point_cloud;
+    std::vector<rviz_rendering::PointCloud::Point> points;
     float size;
-    tesseract_geometry::Octree::SubType shape_type;
 
-    rviz::PointCloud* clone();
+    rviz_rendering::PointCloud* clone();
   };
 
   std::vector<OctreeDataContainer> visual_current_octrees_;     ///< The object representing the visual of this link (if
@@ -323,21 +325,21 @@ private:
                                                                 ///< they
                                                                 /// exist)
 
-  std::vector<rviz::PointCloud*> visual_start_octrees_;  ///< The object representing the visual of this link (if they
+  std::vector<rviz_rendering::PointCloud*> visual_start_octrees_;  ///< The object representing the visual of this link (if they
                                                          ///< exist)
-  std::vector<rviz::PointCloud*> collision_start_octrees_;  ///< The object representing the visual of this link (if
+  std::vector<rviz_rendering::PointCloud*> collision_start_octrees_;  ///< The object representing the visual of this link (if
                                                             ///< they
                                                             /// exist)
 
-  std::vector<rviz::PointCloud*> visual_trajectory_octrees_;  ///< The object representing the visual of this link (if
+  std::vector<rviz_rendering::PointCloud*> visual_trajectory_octrees_;  ///< The object representing the visual of this link (if
                                                               ///< they exist)
-  std::vector<rviz::PointCloud*> collision_trajectory_octrees_;  ///< The object representing the visual of this link
+  std::vector<rviz_rendering::PointCloud*> collision_trajectory_octrees_;  ///< The object representing the visual of this link
                                                                  ///< (if they
                                                                  /// exist)
 
-  std::vector<rviz::PointCloud*> visual_end_octrees_;     ///< The object representing the visual of this link (if they
+  std::vector<rviz_rendering::PointCloud*> visual_end_octrees_;     ///< The object representing the visual of this link (if they
                                                           ///< exist)
-  std::vector<rviz::PointCloud*> collision_end_octrees_;  ///< The object representing the visual of this link (if they
+  std::vector<rviz_rendering::PointCloud*> collision_end_octrees_;  ///< The object representing the visual of this link (if they
                                                           /// exist)
 
   Ogre::SceneNode* visual_current_node_;     ///< The scene node the visual meshes are attached to
@@ -349,11 +351,15 @@ private:
   Ogre::SceneNode* visual_trajectory_node_;
   Ogre::SceneNode* collision_trajectory_node_;
   std::vector<Ogre::SceneNode*> visual_trajectory_waypoint_nodes_;
+  std::vector<bool> visual_trajectory_waypoint_visibility_;  // cache visibility state for toggling collision/visual
+                                                             // visibility
   std::vector<Ogre::SceneNode*> collision_trajectory_waypoint_nodes_;
+  std::vector<bool> collision_trajectory_waypoint_visibility_;  // cache visibility state for toggling collision/visual
+                                                                // visibility
 
   Ogre::RibbonTrail* trail_;
 
-  std::unique_ptr<rviz::Axes> axes_;
+  rviz_rendering::Axes* axes_;
 
   float material_alpha_;  ///< If material is not a texture, this saves the alpha value set in the URDF, otherwise is
                           /// 1.0.

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/manipulation_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/manipulation_widget.h
@@ -36,7 +36,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <ros/ros.h>
 #include <tesseract_msgs/Trajectory.h>
-#include <tesseract/tesseract.h>
+#include <tesseract_environment/environment.h>
 #include <sensor_msgs/JointState.h>
 #include <boost/thread/mutex.hpp>
 #include <tesseract_kinematics/core/inverse_kinematics.h>
@@ -69,8 +69,8 @@ class ManipulationWidget : public QObject
   Q_OBJECT
 
 public:
-  using SharedPtr = std::shared_ptr<ManipulationWidget>;
-  using ConstSharedPtr = std::shared_ptr<const ManipulationWidget>;
+  using Ptr = std::shared_ptr<ManipulationWidget>;
+  using ConstPtr = std::shared_ptr<const ManipulationWidget>;
 
   enum class ManipulatorState
   {
@@ -84,11 +84,11 @@ public:
 
   void onInitialize(Ogre::SceneNode* root_node,
                     rviz_common::DisplayContext* context,
-                    VisualizationWidget::SharedPtr visualization,
-                    tesseract::Tesseract::Ptr tesseract,
-                    ros::NodeHandle update_nh,
+                    VisualizationWidget::Ptr visualization,
+                    tesseract_environment::Environment::Ptr env,
+                    rclcpp::Node::SharedPtr update_node,
                     ManipulatorState state,
-                    QString joint_state_topic);
+                    const QString& joint_state_topic);
 
   void onEnable();
   void onDisable();
@@ -99,32 +99,36 @@ public:
 
 Q_SIGNALS:
   void availableManipulatorsChanged(QStringList manipulators);
-  void availableTCPLinksChanged(QStringList tcp_links);
+  void availableTCPFramesChanged(QStringList tcp_frames);
+  void availableTCPOffsetsChanged(tesseract_common::TransformMap tcp_offsets);
 
 public
   Q_SLOT : void enableCartesianManipulation(bool enabled);
   void enableJointManipulation(bool enabled);
   void resetToCurrentState();
-  bool changeManipulator(QString manipulator);
-  bool changeTCP(QString tcp_link);
+  bool changeManipulator(const QString& manipulator);
+  bool changeTCPFrame(const QString& tcp_frame);
+  bool changeTCPOffset(const QString& tcp_offset);
 
 private Q_SLOTS:
   void changedManipulator();
-  void changedTCP();
+  void changedTCPFrame();
+  void changedTCPOffset();
   void changedJointStateTopic();
   void changedCartesianMarkerScale();
   void changedCartesianManipulationEnabled();
   void changedJointMarkerScale();
   void changedJointManipulationEnabled();
   void clickedResetToCurrentState();
-  void markerFeedback(std::string reference_frame,
-                      Eigen::Isometry3d transform,
-                      Eigen::Vector3d mouse_point,
+  void userInputJointValuesChanged();
+  void markerFeedback(const std::string& reference_frame,
+                      const Eigen::Isometry3d& transform,
+                      const Eigen::Vector3d& mouse_point,
                       bool mouse_point_valid);
-  void jointMarkerFeedback(std::string joint_name,
-                           std::string reference_frame,
-                           Eigen::Isometry3d transform,
-                           Eigen::Vector3d mouse_point,
+  void jointMarkerFeedback(const std::string& joint_name,
+                           const std::string& reference_frame,
+                           const Eigen::Isometry3d& transform,
+                           const Eigen::Vector3d& mouse_point,
                            bool mouse_point_valid);
   //  void trajectorySliderPanelVisibilityChange(bool enable);
 

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/trajectory_monitor_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/trajectory_monitor_widget.h
@@ -39,25 +39,30 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <rviz/display.h>
-#include <rviz/panel_dock_widget.h>
+#include <rviz_common/display.hpp>
+#include <rviz_common/panel_dock_widget.hpp>
 #include <boost/thread/mutex.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #ifndef Q_MOC_RUN
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <ros/ros.h>
-#include <tesseract_msgs/Trajectory.h>
-#include <tesseract_environment/environment.h>
-#include <tesseract_common/types.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tesseract_msgs/msg/trajectory.hpp>
+#include <tesseract/tesseract.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #endif
 
-#include <tesseract_rviz/render_tools/visualize_trajectory_widget.h>
+#include <tesseract_rviz/render_tools/visualization_widget.h>
+#include <tesseract_rviz/render_tools/trajectory_panel.h>
 
-namespace rviz
+namespace rviz_rendering
 {
 class Shape;
+class MovableText;
+}
+
+namespace rviz_common::properties
+{
 class Property;
 class IntProperty;
 class StringProperty;
@@ -67,7 +72,6 @@ class RosTopicProperty;
 class EditableEnumProperty;
 class EnumProperty;
 class ColorProperty;
-class MovableText;
 }  // namespace rviz
 
 namespace tesseract_rviz
@@ -77,53 +81,73 @@ class TrajectoryMonitorWidget : public QObject
   Q_OBJECT
 
 public:
-  using Ptr = std::shared_ptr<TrajectoryMonitorWidget>;
-  using ConstPtr = std::shared_ptr<const TrajectoryMonitorWidget>;
+  using SharedPtr = std::shared_ptr<TrajectoryMonitorWidget>;
+  using ConstSharedPtr = std::shared_ptr<const TrajectoryMonitorWidget>;
 
-  TrajectoryMonitorWidget(rviz::Property* widget, rviz::Display* display);
+  TrajectoryMonitorWidget(rviz_common::properties::Property* widget, rviz_common::Display* display);
 
   virtual ~TrajectoryMonitorWidget();
 
-  void onInitialize(VisualizationWidget::Ptr visualization,
-                    tesseract_environment::Environment::Ptr env,
-                    rviz::DisplayContext* context,
-                    const ros::NodeHandle& update_nh);
+  void onInitialize(VisualizationWidget::SharedPtr visualization,
+                    tesseract::Tesseract::Ptr tesseract,
+                    rviz_common::DisplayContext* context,
+                    rclcpp::Node::SharedPtr update_node);
 
   void onEnable();
   void onDisable();
-  void onReset();
   void onUpdate(float wall_dt);
+  void onReset();
   void onNameChange(const QString& name);
 
-private Q_SLOTS:
-  void changedTrajectoryTopic();
+  void dropTrajectory();
 
-public:
-  void incomingDisplayTrajectory(const tesseract_msgs::Trajectory::ConstPtr& msg);
+public Q_SLOTS:
+  void interruptCurrentDisplay();
+
+private Q_SLOTS:
+  void changedDisplayMode();
+  void changedTrailStepSize();
+  void changedTrajectoryTopic();
+  void changedStateDisplayTime();
+  void trajectorySliderPanelVisibilityChange(bool enable);
 
 protected:
-  rviz::Property* widget_;
-  rviz::Display* display_;
-  rviz::DisplayContext* context_;
-  ros::NodeHandle nh_;
-  VisualizeTrajectoryWidget::Ptr visualize_trajectory_widget_;
+  void incomingDisplayTrajectory(const tesseract_msgs::msg::Trajectory::ConstSharedPtr msg);
+  float getStateDisplayTime();
+  void clearTrajectoryTrail();
+  void createTrajectoryTrail();
 
-  /**
-   * @brief These are the command that were pushed to motion planning
-   * @details Visualization only supports moving objects around in a trajectory visualization.
-   * If it includes commands which delete or adds links visualization may not be correct.
-   * @todo Need to maintain two environments one which tracks the monitored environment and then
-   * when new request are recieved it clones this environment an applys the commands througout the
-   * trajectory widget.
-   */
-  tesseract_environment::Commands trajectory_env_commands_;
+  rviz_common::properties::Property* widget_;
+  rviz_common::Display* display_;
+  rviz_common::DisplayContext* context_;
+  VisualizationWidget::SharedPtr visualization_;
+  tesseract::Tesseract::Ptr tesseract_;
+  rclcpp::Node::SharedPtr node_;
+  bool cached_visible_; /**< @brief This caches if the trajectory was visible for enable and disble calls */
 
-  ros::Subscriber trajectory_topic_sub_;
+  tesseract_msgs::msg::Trajectory::SharedPtr displaying_trajectory_message_;
+  tesseract_msgs::msg::Trajectory::SharedPtr trajectory_message_to_display_;
+
+  rclcpp::Subscription<tesseract_msgs::msg::Trajectory>::SharedPtr trajectory_topic_sub_;
   boost::mutex update_trajectory_message_;
 
+  // Pointers from parent display that we save
+  bool animating_path_;
+  bool drop_displaying_trajectory_;
+  int current_state_;
+  float current_state_time_;
+  TrajectoryPanel* trajectory_slider_panel_;
+  rviz_common::PanelDockWidget* trajectory_slider_dock_panel_;
+  int previous_display_mode_;
+  size_t num_trajectory_waypoints_;
+
   // Properties
-  rviz::Property* main_property_;
-  rviz::RosTopicProperty* trajectory_topic_property_;
+  rviz_common::properties::Property* main_property_;
+  rviz_common::properties::EditableEnumProperty* state_display_time_property_;
+  rviz_common::properties::RosTopicProperty* trajectory_topic_property_;
+  rviz_common::properties::EnumProperty* display_mode_property_;
+  rviz_common::properties::BoolProperty* interrupt_display_property_;
+  rviz_common::properties::IntProperty* trail_step_size_property_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/trajectory_panel.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/trajectory_panel.h
@@ -41,7 +41,7 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 
 #ifndef Q_MOC_RUN
-//#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #endif
 
 #include <rviz_common/panel.hpp>

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/trajectory_panel.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/trajectory_panel.h
@@ -41,10 +41,10 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 
 #ifndef Q_MOC_RUN
-#include <ros/ros.h>
+//#include <ros/ros.h>
 #endif
 
-#include <rviz/panel.h>
+#include <rviz_common/panel.hpp>
 
 #include <QSlider>
 #include <QLabel>
@@ -53,7 +53,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_rviz
 {
-class TrajectoryPanel : public rviz::Panel
+class TrajectoryPanel : public rviz_common::Panel
 {
   Q_OBJECT
 

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/visualization_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/visualization_widget.h
@@ -93,7 +93,7 @@ using AlignedMap = std::map<Key, Value, std::less<Key>, Eigen::aligned_allocator
 using TransformMap = AlignedMap<std::string, Eigen::Isometry3d>;
 
 /**
- * \class EnvVisualization
+ * \class VisualizationWidget
  *
  * A helper class to draw a representation of a environment.  Can display either the visual models of
  * the environment, or the collision models.

--- a/tesseract_rviz/include/tesseract_rviz/render_tools/visualize_trajectory_widget.h
+++ b/tesseract_rviz/include/tesseract_rviz/render_tools/visualize_trajectory_widget.h
@@ -38,28 +38,29 @@
 #define TESSERACT_RVIZ_VISUALIZE_TRAJECTORY_WIDGET
 
 #include <tesseract_common/macros.h>
-TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <rviz/display.h>
-#include <rviz/panel_dock_widget.h>
-#include <boost/thread/mutex.hpp>
-TESSERACT_COMMON_IGNORE_WARNINGS_POP
-
 #ifndef Q_MOC_RUN
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <ros/ros.h>
-#include <tesseract_msgs/Trajectory.h>
 #include <tesseract_environment/environment.h>
 #include <tesseract_visualization/trajectory_player.h>
 #include <tesseract_common/types.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #endif
 
+#include <tesseract_msgs/msg/trajectory.hpp>
+#include <rviz_common/display.hpp>
+#include <rviz_common/panel_dock_widget.hpp>
+#include <boost/thread/mutex.hpp>
+
 #include <tesseract_rviz/render_tools/visualization_widget.h>
 #include <tesseract_rviz/render_tools/trajectory_panel.h>
 
-namespace rviz
+namespace rviz_common
 {
 class Shape;
+class MovableText;
+
+namespace properties
+{
 class Property;
 class IntProperty;
 class StringProperty;
@@ -68,8 +69,8 @@ class FloatProperty;
 class EditableEnumProperty;
 class EnumProperty;
 class ColorProperty;
-class MovableText;
-}  // namespace rviz
+}  // namespace properties
+}  // namespace rviz_common
 
 namespace tesseract_rviz
 {
@@ -81,13 +82,13 @@ public:
   using Ptr = std::shared_ptr<VisualizeTrajectoryWidget>;
   using ConstPtr = std::shared_ptr<const VisualizeTrajectoryWidget>;
 
-  VisualizeTrajectoryWidget(rviz::Property* widget, rviz::Display* display);
+  VisualizeTrajectoryWidget(rviz_common::properties::Property* widget, rviz_common::Display* display);
 
   virtual ~VisualizeTrajectoryWidget();
 
   void onInitialize(VisualizationWidget::Ptr visualization,
                     tesseract_environment::Environment::Ptr env,
-                    rviz::DisplayContext* context);
+                    rviz_common::DisplayContext* context);
 
   void onEnable();
   void onDisable();
@@ -107,7 +108,7 @@ private Q_SLOTS:
   void trajectorySliderPanelVisibilityChange(bool enable);
 
 public:
-  void setDisplayTrajectory(const tesseract_msgs::Trajectory::ConstPtr& msg);
+  void setDisplayTrajectory(const tesseract_msgs::msg::Trajectory& msg);
 
   void setEnvironment(tesseract_environment::Environment::Ptr env);
 
@@ -115,9 +116,9 @@ protected:
   void clearTrajectoryTrail();
   void createTrajectoryTrail();
 
-  rviz::Property* widget_;
-  rviz::Display* display_;
-  rviz::DisplayContext* context_;
+  rviz_common::properties::Property* widget_;
+  rviz_common::Display* display_;
+  rviz_common::DisplayContext* context_;
   VisualizationWidget::Ptr visualization_;
   tesseract_environment::Environment::Ptr env_;
   bool cached_visible_{ false }; /**< @brief This caches if the trajectory was visible for enable and disble calls */
@@ -142,17 +143,17 @@ protected:
   bool animating_path_{ false };
   bool drop_displaying_trajectory_{ false };
   TrajectoryPanel* trajectory_slider_panel_;
-  rviz::PanelDockWidget* trajectory_slider_dock_panel_;
+  rviz_common::PanelDockWidget* trajectory_slider_dock_panel_;
   int previous_display_mode_;
   std::size_t num_trail_waypoints_;
   int slider_count_;
 
   // Properties
-  rviz::Property* main_property_;
-  rviz::FloatProperty* time_scale_property_;
-  rviz::EnumProperty* display_mode_property_;
-  rviz::BoolProperty* interrupt_display_property_;
-  rviz::IntProperty* trail_step_size_property_;
+  rviz_common::properties::Property* main_property_;
+  rviz_common::properties::FloatProperty* time_scale_property_;
+  rviz_common::properties::EnumProperty* display_mode_property_;
+  rviz_common::properties::BoolProperty* interrupt_display_property_;
+  rviz_common::properties::IntProperty* trail_step_size_property_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/tesseract_manipulation_plugin/tesseract_manipulation_display.h
+++ b/tesseract_rviz/include/tesseract_rviz/tesseract_manipulation_plugin/tesseract_manipulation_display.h
@@ -31,7 +31,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <rviz/display.h>
 #ifndef Q_MOC_RUN
 #include <ros/ros.h>
-#include <tesseract_environment/environment.h>
+#include <tesseract/tesseract.h>
 #endif
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
@@ -41,7 +41,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_rviz
 {
-class TesseractManipulationDisplay : public rviz::Display
+class TesseractManipulationDisplay : public rviz_common::Display
 {
   Q_OBJECT
 
@@ -63,10 +63,10 @@ protected:
   // ROS Node Handle
   ros::NodeHandle nh_;
 
-  tesseract_environment::Environment::Ptr env_;
-  VisualizationWidget::Ptr visualization_;
-  EnvironmentWidget::Ptr environment_monitor_;
-  ManipulationWidget::Ptr manipulation_;
+  tesseract::Tesseract::Ptr tesseract_;
+  VisualizationWidget::SharedPtr visualization_;
+  EnvironmentWidget::SharedPtr environment_monitor_;
+  ManipulationWidget::SharedPtr manipulation_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/tesseract_scene_plugin/tesseract_scene_display.h
+++ b/tesseract_rviz/include/tesseract_rviz/tesseract_scene_plugin/tesseract_scene_display.h
@@ -66,7 +66,7 @@ namespace tesseract_rviz
 {
 class Robot;
 
-class TesseractSceneDisplay : public rviz::Display
+class TesseractSceneDisplay : public rviz_common::Display
 {
   Q_OBJECT
 
@@ -192,23 +192,23 @@ protected:
   bool tesseract_scene_needs_render_;
   float current_scene_time_;
 
-  rviz::Property* scene_category_;
-  rviz::Property* robot_category_;
+  rviz_common::properties::Property* scene_category_;
+  rviz_common::properties::Property* robot_category_;
 
-  rviz::StringProperty* move_group_ns_property_;
-  rviz::StringProperty* robot_description_property_;
-  rviz::StringProperty* scene_name_property_;
-  rviz::BoolProperty* scene_enabled_property_;
-  rviz::BoolProperty* scene_robot_visual_enabled_property_;
-  rviz::BoolProperty* scene_robot_collision_enabled_property_;
-  rviz::RosTopicProperty* planning_scene_topic_property_;
-  rviz::FloatProperty* robot_alpha_property_;
-  rviz::FloatProperty* scene_alpha_property_;
+  rviz_common::properties::StringProperty* move_group_ns_property_;
+  rviz_common::properties::StringProperty* robot_description_property_;
+  rviz_common::properties::StringProperty* scene_name_property_;
+  rviz_common::properties::BoolProperty* scene_enabled_property_;
+  rviz_common::properties::BoolProperty* scene_robot_visual_enabled_property_;
+  rviz_common::properties::BoolProperty* scene_robot_collision_enabled_property_;
+  rviz_common::properties::RosTopicProperty* planning_scene_topic_property_;
+  rviz_common::properties::FloatProperty* robot_alpha_property_;
+  rviz_common::properties::FloatProperty* scene_alpha_property_;
   rviz::ColorProperty* scene_color_property_;
   rviz::ColorProperty* attached_body_color_property_;
-  rviz::FloatProperty* scene_display_time_property_;
-  rviz::EnumProperty* octree_render_property_;
-  rviz::EnumProperty* octree_coloring_property_;
+  rviz_common::properties::FloatProperty* scene_display_time_property_;
+  rviz_common::properties::EnumProperty* octree_render_property_;
+  rviz_common::properties::EnumProperty* octree_coloring_property_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h
+++ b/tesseract_rviz/include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h
@@ -44,7 +44,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <rviz_common/display.hpp>
 #ifndef Q_MOC_RUN
 #include <rclcpp/rclcpp.hpp>
-#include <tesseract/tesseract.h>
+#include <tesseract_environment/environment.h>
 #endif
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
@@ -66,7 +66,9 @@ public:
 
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
-//  void setName(const QString& name) override;  // TODO: Figure this out for ROS 2
+
+  // Now declared as final in rviz_common::Display
+  // void setName(const QString& name) override;
 
 protected:
   // overrides from Display
@@ -77,11 +79,11 @@ protected:
   // ROS Node Handle
   rclcpp::Node::SharedPtr node_;
 
-  tesseract::Tesseract::Ptr tesseract_;
-  VisualizationWidget::SharedPtr visualization_;
-  JointStateMonitorWidget::SharedPtr state_monitor_;
-  EnvironmentWidget::SharedPtr environment_monitor_;
-  TrajectoryMonitorWidget::SharedPtr trajectory_monitor_;
+  tesseract_environment::Environment::Ptr env_;
+  VisualizationWidget::Ptr visualization_;
+  JointStateMonitorWidget::Ptr state_monitor_;
+  EnvironmentWidget::Ptr environment_monitor_;
+  TrajectoryMonitorWidget::Ptr trajectory_monitor_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h
+++ b/tesseract_rviz/include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h
@@ -41,10 +41,10 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <rviz/display.h>
+#include <rviz_common/display.hpp>
 #ifndef Q_MOC_RUN
-#include <ros/ros.h>
-#include <tesseract_environment/environment.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tesseract/tesseract.h>
 #endif
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
@@ -55,7 +55,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_rviz
 {
-class TesseractTrajectoryDisplay : public rviz::Display
+class TesseractTrajectoryDisplay : public rviz_common::Display
 {
   Q_OBJECT
 
@@ -66,7 +66,7 @@ public:
 
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
-  void setName(const QString& name) override;
+//  void setName(const QString& name) override;  // TODO: Figure this out for ROS 2
 
 protected:
   // overrides from Display
@@ -75,13 +75,13 @@ protected:
   void onDisable() override;
 
   // ROS Node Handle
-  ros::NodeHandle nh_;
+  rclcpp::Node::SharedPtr node_;
 
-  tesseract_environment::Environment::Ptr env_;
-  VisualizationWidget::Ptr visualization_;
-  JointStateMonitorWidget::Ptr state_monitor_;
-  EnvironmentWidget::Ptr environment_monitor_;
-  TrajectoryMonitorWidget::Ptr trajectory_monitor_;
+  tesseract::Tesseract::Ptr tesseract_;
+  VisualizationWidget::SharedPtr visualization_;
+  JointStateMonitorWidget::SharedPtr state_monitor_;
+  EnvironmentWidget::SharedPtr environment_monitor_;
+  TrajectoryMonitorWidget::SharedPtr trajectory_monitor_;
 };
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h
+++ b/tesseract_rviz/include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h
@@ -77,7 +77,7 @@ protected:
   void onDisable() override;
 
   // ROS Node Handle
-  rclcpp::Node::SharedPtr node_;
+  rclcpp::Node::SharedPtr node_ = nullptr;
 
   tesseract_environment::Environment::Ptr env_;
   VisualizationWidget::Ptr visualization_;

--- a/tesseract_rviz/package.xml
+++ b/tesseract_rviz/package.xml
@@ -14,7 +14,7 @@
   <depend>pluginlib</depend>
   <depend>interactive_markers</depend>
   <depend>tesseract_msgs</depend>
-  <depend>tesseract</depend>
+  <depend>tesseract_monitoring</depend>
   <depend>tesseract_rosutils</depend>
   <depend>Qt5</depend>
   <depend>libconsole-bridge</depend>

--- a/tesseract_rviz/package.xml
+++ b/tesseract_rviz/package.xml
@@ -2,33 +2,27 @@
 <package format="2">
   <name>tesseract_rviz</name>
   <version>0.1.0</version>
-  <description>The tesseract_rviz package</description>
+  <description>The tesseract_rviz package for ROS 2</description>
   <maintainer email="Armstrong@todo.todo">Levi Armstrong</maintainer>
   <license>BSD</license>
   <author >Levi Armstrong</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>ros_industrial_cmake_boilerplate</build_depend>
-
-  <depend>tesseract_msgs</depend>
-  <depend>tesseract_environment</depend>
-  <depend>tesseract_rosutils</depend>
-  <depend>tesseract_common</depend>
-  <depend>tesseract_monitoring</depend>
-  <depend>tesseract_motion_planners</depend>
-
-  <build_depend>eigen</build_depend>
-  <build_export_depend>eigen</build_export_depend>
-  <depend>interactive_markers</depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>rviz2</depend>
   <depend>message_generation</depend>
   <depend>pluginlib</depend>
-  <depend>roscpp</depend>
-  <depend>rviz</depend>
+  <depend>interactive_markers</depend>
+  <depend>tesseract_msgs</depend>
+  <depend>tesseract</depend>
+  <depend>tesseract_rosutils</depend>
+  <depend>Qt5</depend>
+  <depend>libconsole-bridge</depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
     <rviz plugin="${prefix}/tesseract_rviz_state_plugin_description.xml"/>
     <rviz plugin="${prefix}/tesseract_rviz_trajectory_plugin_description.xml"/>
-    <rviz plugin="${prefix}/tesseract_rviz_planning_response_archive_plugin_description.xml"/>
     <rviz plugin="${prefix}/tesseract_rviz_manipulation_plugin_description.xml"/>
   </export>
 </package>

--- a/tesseract_rviz/src/environment_state_plugin/environment_state_display.cpp
+++ b/tesseract_rviz/src/environment_state_plugin/environment_state_display.cpp
@@ -58,15 +58,9 @@ void EnvironmentStateDisplay::onInitialize()
 {
   Display::onInitialize();
 
-  node_ = context_->getRosNodeAbstraction().lock()->get_raw_node();
-  timer_ = node_->create_wall_timer(std::chrono::seconds{2},
-      [this]()
-      {
-        RCLCPP_INFO(node_->get_logger(), "Callback!");
-      }
-  );
   visualization_ = std::make_shared<VisualizationWidget>(scene_node_, context_, "Tesseract State", this);
 
+  node_ = context_->getRosNodeAbstraction().lock()->get_raw_node();
   environment_widget_->onInitialize(visualization_, env_, context_, node_, false);
   state_monitor_->onInitialize(visualization_, env_, context_, node_);
 

--- a/tesseract_rviz/src/environment_state_plugin/environment_state_display.cpp
+++ b/tesseract_rviz/src/environment_state_plugin/environment_state_display.cpp
@@ -35,42 +35,41 @@
 /* Author: Ioan Sucan */
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <ros/package.h>
 
-#include <eigen_conversions/eigen_msg.h>
-#include <rviz/display_context.h>
-#include <rviz/frame_manager.h>
-#include <rviz/visualization_manager.h>
+//#include <eigen_conversions/eigen_msg.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/frame_manager_iface.hpp>
+//#include <rviz_common/visualization_manager.hpp>
 
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-#include <tesseract_rviz/environment_state_plugin/environment_state_display.h>
+#include <tesseract_rviz/tesseract_state_plugin/tesseract_state_display.h>
 
 namespace tesseract_rviz
 {
-EnvironmentStateDisplay::EnvironmentStateDisplay()
+TesseractStateDisplay::TesseractStateDisplay() : Display(), node_(new rclcpp::Node("tesseract_state_display"))
 {
-  env_ = std::make_shared<tesseract_environment::Environment>();
+  tesseract_ = std::make_shared<tesseract::Tesseract>();
   environment_monitor_ = std::make_shared<EnvironmentWidget>(this, this);
   state_monitor_ = std::make_shared<JointStateMonitorWidget>(this, this);
 }
 
-EnvironmentStateDisplay::~EnvironmentStateDisplay() = default;
+TesseractStateDisplay::~TesseractStateDisplay() {}
 
-void EnvironmentStateDisplay::onInitialize()
+void TesseractStateDisplay::onInitialize()
 {
   Display::onInitialize();
   visualization_ = std::make_shared<VisualizationWidget>(scene_node_, context_, "Tesseract State", this);
 
-  environment_monitor_->onInitialize(visualization_, env_, context_, nh_, false);
-  state_monitor_->onInitialize(visualization_, env_, context_, nh_);
+  environment_monitor_->onInitialize(visualization_, tesseract_, context_, node_, false);
+  state_monitor_->onInitialize(visualization_, tesseract_, context_, node_);
 
   visualization_->setVisible(false);
 }
 
-void EnvironmentStateDisplay::reset()
+void TesseractStateDisplay::reset()
 {
   visualization_->clear();
   Display::reset();
@@ -79,7 +78,7 @@ void EnvironmentStateDisplay::reset()
   state_monitor_->onReset();
 }
 
-void EnvironmentStateDisplay::onEnable()
+void TesseractStateDisplay::onEnable()
 {
   Display::onEnable();
 
@@ -87,7 +86,7 @@ void EnvironmentStateDisplay::onEnable()
   state_monitor_->onEnable();
 }
 
-void EnvironmentStateDisplay::onDisable()
+void TesseractStateDisplay::onDisable()
 {
   environment_monitor_->onDisable();
   state_monitor_->onDisable();
@@ -95,7 +94,7 @@ void EnvironmentStateDisplay::onDisable()
   Display::onDisable();
 }
 
-void EnvironmentStateDisplay::update(float wall_dt, float ros_dt)
+void TesseractStateDisplay::update(float wall_dt, float ros_dt)
 {
   Display::update(wall_dt, ros_dt);
 
@@ -106,7 +105,7 @@ void EnvironmentStateDisplay::update(float wall_dt, float ros_dt)
 // ******************************************************************************************
 // Calculate Offset Position
 // ******************************************************************************************
-// void EnvironmentStateDisplay::calculateOffsetPosition()
+// void TesseractStateDisplay::calculateOffsetPosition()
 //{
 //  if (!env_)
 //    return;
@@ -119,7 +118,7 @@ void EnvironmentStateDisplay::update(float wall_dt, float ros_dt)
 //  scene_node_->setOrientation(orientation);
 //}
 
-// void EnvironmentStateDisplay::fixedFrameChanged()
+// void TesseractStateDisplay::fixedFrameChanged()
 //{
 //  Display::fixedFrameChanged();
 //  calculateOffsetPosition();

--- a/tesseract_rviz/src/environment_state_plugin/plugin_init.cpp
+++ b/tesseract_rviz/src/environment_state_plugin/plugin_init.cpp
@@ -5,4 +5,4 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/environment_state_plugin/environment_state_display.h>
 
-CLASS_LOADER_REGISTER_CLASS(tesseract_rviz::EnvironmentStateDisplay, rviz::Display)
+CLASS_LOADER_REGISTER_CLASS(tesseract_rviz::EnvironmentStateDisplay, rviz_common::Display)

--- a/tesseract_rviz/src/interactive_marker/interactive_marker_control.cpp
+++ b/tesseract_rviz/src/interactive_marker/interactive_marker_control.cpp
@@ -38,15 +38,15 @@
 #include <OgreSharedPtr.h>
 #include <OgreTechnique.h>
 
-#include "rviz/display_context.h"
-#include "rviz/selection/selection_manager.h"
-#include "rviz/render_panel.h"
-#include "rviz/load_resource.h"
-#include "rviz/window_manager_interface.h"
-#include "rviz/geometry.h"
-#include "rviz/frame_manager.h"
+#include "rviz_common/display_context.hpp"
+#include "rviz_common/interaction/selection_manager.hpp"
+#include "rviz_common/render_panel.hpp"
+#include "rviz_common/load_resource.hpp"
+#include "rviz_common/window_manager_interface.hpp"
+#include "rviz_rendering/geometry.hpp"
+#include "rviz_common/frame_manager_iface.hpp"
 
-#include "rviz/ogre_helpers/line.h"
+#include "rviz_rendering/objects/line.hpp"
 
 //#include "rviz/default_plugin/marker_utils.h"
 //#include "rviz/default_plugin/markers/points_marker.h"
@@ -59,15 +59,15 @@
 #include <tesseract_rviz/markers/marker_base.h>
 #include <tesseract_rviz/markers/utils.h>
 
-#define NO_HIGHLIGHT_VALUE 0.0f
-#define ACTIVE_HIGHLIGHT_VALUE 0.5f
-#define HOVER_HIGHLIGHT_VALUE 0.3f
+#define NO_HIGHLIGHT_VALUE 0.0
+#define ACTIVE_HIGHLIGHT_VALUE 0.5
+#define HOVER_HIGHLIGHT_VALUE 0.3
 
 namespace tesseract_rviz
 {
-InteractiveMarkerControl::InteractiveMarkerControl(std::string name,
+InteractiveMarkerControl::InteractiveMarkerControl(const std::string& name,
                                                    const std::string& description,
-                                                   rviz::DisplayContext* context,
+                                                   rviz_common::DisplayContext* context,
                                                    Ogre::SceneNode* reference_node,
                                                    InteractiveMarker* parent,
                                                    const InteractiveMode interactive_mode,
@@ -80,12 +80,6 @@ InteractiveMarkerControl::InteractiveMarkerControl(std::string name,
   , reference_node_(reference_node)
   , control_frame_node_(reference_node_->createChildSceneNode())
   , markers_node_(reference_node_->createChildSceneNode())
-  , interaction_mode_(interactive_mode)
-  , orientation_mode_(orientation_mode)
-  , control_orientation_(orientation)
-  , always_visible_(always_visible)
-  , description_(QString::fromStdString(description))
-  , name_(std::move(name))
   , parent_(parent)
   , rotation_(0)
   , grab_point_in_reference_frame_(0, 0, 0)
@@ -93,7 +87,13 @@ InteractiveMarkerControl::InteractiveMarkerControl(std::string name,
   , visible_(true)
   , view_facing_(false)
   , mouse_down_(false)
+  , name_(name)
+  , description_(QString::fromStdString(description))
   , show_visual_aids_(false)
+  , interaction_mode_(interactive_mode)
+  , always_visible_(always_visible)
+  , orientation_mode_(orientation_mode)
+  , control_orientation_(orientation)
 //, line_(new Line(context->getSceneManager(),control_frame_node_))
 {
   //  line_->setVisible(false);
@@ -133,7 +133,7 @@ InteractiveMarkerControl::InteractiveMarkerControl(std::string name,
 
   status_msg_ = description_ + " ";
 
-  //  Ogre::Vector3 control_dir = control_orientation_.xAxis() * 10000.0;
+  Ogre::Vector3 control_dir = control_orientation_.xAxis() * 10000.0;
   //  line_->setPoints( control_dir, -1*control_dir );
   //  line_->setVisible(false);
 
@@ -141,42 +141,42 @@ InteractiveMarkerControl::InteractiveMarkerControl(std::string name,
   switch (interaction_mode_)
   {
     case InteractiveMode::NONE:
-      cursor_ = rviz::getDefaultCursor();
+      cursor_ = rviz_common::getDefaultCursor();
       break;
     case InteractiveMode::MENU:
-      cursor_ = rviz::makeIconCursor("package://rviz/icons/menu.svg");
+      cursor_ = rviz_common::makeIconCursor("package://rviz/icons/menu.svg");
       status_msg_ += "<b>Left-Click:</b> Show menu.";
       break;
     case InteractiveMode::BUTTON:
-      cursor_ = rviz::getDefaultCursor();
+      cursor_ = rviz_common::getDefaultCursor();
       status_msg_ += "<b>Left-Click:</b> Activate. ";
       break;
     case InteractiveMode::MOVE_AXIS:
-      cursor_ = rviz::makeIconCursor("package://rviz/icons/move1d.svg");
+      cursor_ = rviz_common::makeIconCursor("package://rviz/icons/move1d.svg");
       status_msg_ += "<b>Left-Click:</b> Move. ";
       break;
     case InteractiveMode::MOVE_PLANE:
-      cursor_ = rviz::makeIconCursor("package://rviz/icons/move2d.svg");
+      cursor_ = rviz_common::makeIconCursor("package://rviz/icons/move2d.svg");
       status_msg_ += "<b>Left-Click:</b> Move. ";
       break;
     case InteractiveMode::ROTATE_AXIS:
-      cursor_ = rviz::makeIconCursor("package://rviz/icons/rotate.svg");
+      cursor_ = rviz_common::makeIconCursor("package://rviz/icons/rotate.svg");
       status_msg_ += "<b>Left-Click:</b> Rotate. ";
       break;
     case InteractiveMode::MOVE_ROTATE:
-      cursor_ = rviz::makeIconCursor("package://rviz/icons/moverotate.svg");
+      cursor_ = rviz_common::makeIconCursor("package://rviz/icons/moverotate.svg");
       status_msg_ += "<b>Left-Click:</b> Move / Rotate. ";
       break;
     case InteractiveMode::MOVE_3D:
-      cursor_ = rviz::makeIconCursor("package://rviz/icons/move2d.svg");
+      cursor_ = rviz_common::makeIconCursor("package://rviz/icons/move2d.svg");
       status_msg_ += "<b>Left-Click:</b> Move X/Y. <b>Shift + Left-Click / Left-Click + Wheel:</b> Move Z. ";
       break;
     case InteractiveMode::ROTATE_3D:
-      cursor_ = rviz::makeIconCursor("package://rviz/icons/rotate.svg");
+      cursor_ = rviz_common::makeIconCursor("package://rviz/icons/rotate.svg");
       status_msg_ += "<b>Left-Click:</b> Rotate around X/Y. <b>Shift-Left-Click:</b> Rotate around Z. ";
       break;
     case InteractiveMode::MOVE_ROTATE_3D:
-      cursor_ = rviz::makeIconCursor("package://rviz/icons/moverotate.svg");
+      cursor_ = rviz_common::makeIconCursor("package://rviz/icons/moverotate.svg");
       status_msg_ += "<b>Left-Click:</b> Move X/Y. <b>Shift + Left-Click / Left-Click + Wheel:</b> Move Z. <b>Ctrl + "
                      "Left-Click:</b> Rotate around X/Y. <b>Ctrl + Shift + Left-Click:</b> Rotate around Z. ";
       break;
@@ -219,7 +219,7 @@ void InteractiveMarkerControl::updateSize()
 
 Ogre::SceneNode* InteractiveMarkerControl::getMarkerSceneNode() { return markers_node_; }
 
-void InteractiveMarkerControl::addMarker(const MarkerBase::Ptr& marker)
+void InteractiveMarkerControl::addMarker(MarkerBase::SharedPtr marker)
 {
   marker->setInteractiveObject(shared_from_this());
 
@@ -232,8 +232,8 @@ float InteractiveMarkerControl::getSize() { return parent_->getSize(); }
 
 // This is an Ogre::SceneManager::Listener function, and is configured
 // to be called only if this is a VIEW_FACING control.
-void InteractiveMarkerControl::preFindVisibleObjects(Ogre::SceneManager* /*source*/,
-                                                     Ogre::SceneManager::IlluminationRenderStage /*irs*/,
+void InteractiveMarkerControl::preFindVisibleObjects(Ogre::SceneManager* source,
+                                                     Ogre::SceneManager::IlluminationRenderStage irs,
                                                      Ogre::Viewport* v)
 {
   updateControlOrientationForViewFacing(v);
@@ -353,7 +353,7 @@ Ogre::Vector3 InteractiveMarkerControl::closestPointOnLineToPoint(const Ogre::Ve
   //       P + v * -------
   //                 v.v
   //       where "." is the dot product.
-  Ogre::Real factor = (test_point - line_start).dotProduct(line_dir) / line_dir.dotProduct(line_dir);
+  double factor = (test_point - line_start).dotProduct(line_dir) / line_dir.dotProduct(line_dir);
   Ogre::Vector3 closest_point = line_start + line_dir * factor;
   return closest_point;
 }
@@ -384,7 +384,7 @@ void InteractiveMarkerControl::rotate(Ogre::Ray& mouse_ray)
   }
 }
 
-void InteractiveMarkerControl::rotate(const Ogre::Vector3& cursor_position_in_reference_frame)
+void InteractiveMarkerControl::rotate(const Ogre::Vector3& cursor_in_reference_frame)
 {
   Ogre::Vector3 rotation_axis = control_frame_orientation_at_mouse_down_ * control_orientation_.xAxis();
 
@@ -394,7 +394,7 @@ void InteractiveMarkerControl::rotate(const Ogre::Vector3& cursor_position_in_re
       closestPointOnLineToPoint(control_frame_node_->getPosition(), rotation_axis, grab_point_in_reference_frame_);
 
   Ogre::Vector3 grab_rel_center = grab_point_in_reference_frame_ - rotation_center;
-  Ogre::Vector3 center_to_cursor = cursor_position_in_reference_frame - rotation_center;
+  Ogre::Vector3 center_to_cursor = cursor_in_reference_frame - rotation_center;
   Ogre::Vector3 center_to_cursor_radial = center_to_cursor - center_to_cursor.dotProduct(rotation_axis) * rotation_axis;
 
   Ogre::Quaternion orientation_change_since_mouse_down =
@@ -415,13 +415,12 @@ void InteractiveMarkerControl::rotate(const Ogre::Vector3& cursor_position_in_re
       parent_->getPosition(), orientation_change_since_mouse_down * parent_orientation_at_mouse_down_, name_);
 }
 
-Ogre::Ray InteractiveMarkerControl::getMouseRayInReferenceFrame(const rviz::ViewportMouseEvent& event, int x, int y)
+Ogre::Ray InteractiveMarkerControl::getMouseRayInReferenceFrame(const rviz_common::ViewportMouseEvent& event, int x, int y)
 {
-  float width = static_cast<float>(event.viewport->getActualWidth() - 1);
-  float height = static_cast<float>(event.viewport->getActualHeight() - 1);
+  float width = event.viewport->getActualWidth() - 1;
+  float height = event.viewport->getActualHeight() - 1;
 
-  Ogre::Ray mouse_ray = event.viewport->getCamera()->getCameraToViewportRay((static_cast<float>(x) + 0.5f) / width,
-                                                                            (static_cast<float>(y) + 0.5f) / height);
+  Ogre::Ray mouse_ray = event.viewport->getCamera()->getCameraToViewportRay((x + 0.5f) / width, (y + 0.5f) / height);
 
   // convert ray into reference frame
   mouse_ray.setOrigin(reference_node_->convertWorldToLocalPosition(mouse_ray.getOrigin()));
@@ -431,7 +430,7 @@ Ogre::Ray InteractiveMarkerControl::getMouseRayInReferenceFrame(const rviz::View
   return mouse_ray;
 }
 
-void InteractiveMarkerControl::beginRelativeMouseMotion(const rviz::ViewportMouseEvent& event)
+void InteractiveMarkerControl::beginRelativeMouseMotion(const rviz_common::ViewportMouseEvent& event)
 {
   mouse_x_at_drag_begin_ = event.x;
   mouse_y_at_drag_begin_ = event.y;
@@ -443,7 +442,7 @@ void InteractiveMarkerControl::beginRelativeMouseMotion(const rviz::ViewportMous
   mouse_ray_at_drag_begin_.setDirection(mouse_ray_at_drag_begin_.getDirection().normalisedCopy());
 }
 
-bool InteractiveMarkerControl::getRelativeMouseMotion(const rviz::ViewportMouseEvent& event, int& dx, int& dy)
+bool InteractiveMarkerControl::getRelativeMouseMotion(const rviz_common::ViewportMouseEvent& event, int& dx, int& dy)
 {
   dx = event.x - mouse_x_at_drag_begin_;
   dy = event.y - mouse_y_at_drag_begin_;
@@ -455,7 +454,7 @@ bool InteractiveMarkerControl::getRelativeMouseMotion(const rviz::ViewportMouseE
   return true;
 }
 
-void InteractiveMarkerControl::rotateXYRelative(const rviz::ViewportMouseEvent& event)
+void InteractiveMarkerControl::rotateXYRelative(const rviz_common::ViewportMouseEvent& event)
 {
   int dx;
   int dy;
@@ -463,9 +462,9 @@ void InteractiveMarkerControl::rotateXYRelative(const rviz::ViewportMouseEvent& 
   if (!getRelativeMouseMotion(event, dx, dy))
     return;
 
-  static const Ogre::Real MOUSE_SCALE = 2 * 3.14f / 300.0f;  // 300 pixels = 360deg
-  Ogre::Radian rx(static_cast<Ogre::Real>(dx) * MOUSE_SCALE);
-  Ogre::Radian ry(static_cast<Ogre::Real>(dy) * MOUSE_SCALE);
+  static const double MOUSE_SCALE = 2 * 3.14 / 300;  // 300 pixels = 360deg
+  Ogre::Radian rx(dx * MOUSE_SCALE);
+  Ogre::Radian ry(dy * MOUSE_SCALE);
 
   Ogre::Quaternion up_rot(rx, event.viewport->getCamera()->getRealUp());
   Ogre::Quaternion right_rot(ry, event.viewport->getCamera()->getRealRight());
@@ -473,7 +472,7 @@ void InteractiveMarkerControl::rotateXYRelative(const rviz::ViewportMouseEvent& 
   parent_->setPose(parent_->getPosition(), up_rot * right_rot * parent_->getOrientation(), name_);
 }
 
-void InteractiveMarkerControl::rotateZRelative(const rviz::ViewportMouseEvent& event)
+void InteractiveMarkerControl::rotateZRelative(const rviz_common::ViewportMouseEvent& event)
 {
   int dx;
   int dy;
@@ -484,15 +483,15 @@ void InteractiveMarkerControl::rotateZRelative(const rviz::ViewportMouseEvent& e
   if (dx == 0)
     return;
 
-  static const Ogre::Real MOUSE_SCALE = 2 * 3.14f / 300.0f;  // 300 pixels = 360deg
-  Ogre::Radian rx(static_cast<Ogre::Real>(dx) * MOUSE_SCALE);
+  static const double MOUSE_SCALE = 2 * 3.14 / 300;  // 300 pixels = 360deg
+  Ogre::Radian rx(dx * MOUSE_SCALE);
 
   Ogre::Quaternion rot(rx, event.viewport->getCamera()->getRealDirection());
 
   parent_->setPose(parent_->getPosition(), rot * parent_->getOrientation(), name_);
 }
 
-void InteractiveMarkerControl::moveZAxisRelative(const rviz::ViewportMouseEvent& event)
+void InteractiveMarkerControl::moveZAxisRelative(const rviz_common::ViewportMouseEvent& event)
 {
   int dx;
   int dy;
@@ -503,7 +502,7 @@ void InteractiveMarkerControl::moveZAxisRelative(const rviz::ViewportMouseEvent&
   if (dy == 0)
     return;
 
-  Ogre::Real distance = -1.0f * static_cast<Ogre::Real>(dy) * mouse_z_scale_;
+  double distance = -dy * mouse_z_scale_;
   Ogre::Vector3 delta = distance * mouse_ray_at_drag_begin_.getDirection();
 
   parent_->setPose(parent_->getPosition() + delta, parent_->getOrientation(), name_);
@@ -511,12 +510,12 @@ void InteractiveMarkerControl::moveZAxisRelative(const rviz::ViewportMouseEvent&
   parent_position_at_mouse_down_ = parent_->getPosition();
 }
 
-void InteractiveMarkerControl::moveZAxisWheel(const rviz::ViewportMouseEvent& event)
+void InteractiveMarkerControl::moveZAxisWheel(const rviz_common::ViewportMouseEvent& event)
 {
   // wheel_delta is in 1/8 degree and usually jumps 15 degrees at a time
-  static const Ogre::Real WHEEL_TO_PIXEL_SCALE = (1.0f / 8.0f) * (2.0f / 15.0f);  // 2 pixels per click
+  static const double WHEEL_TO_PIXEL_SCALE = (1.0 / 8.0) * (2.0 / 15.0);  // 2 pixels per click
 
-  Ogre::Real distance = static_cast<Ogre::Real>(event.wheel_delta) * WHEEL_TO_PIXEL_SCALE;
+  double distance = event.wheel_delta * WHEEL_TO_PIXEL_SCALE;
   Ogre::Vector3 delta = distance * mouse_ray_at_drag_begin_.getDirection();
 
   parent_->setPose(parent_->getPosition() + delta, parent_->getOrientation(), name_);
@@ -524,7 +523,7 @@ void InteractiveMarkerControl::moveZAxisWheel(const rviz::ViewportMouseEvent& ev
   parent_position_at_mouse_down_ = parent_->getPosition();
 }
 
-void InteractiveMarkerControl::moveViewPlane(Ogre::Ray& mouse_ray, const rviz::ViewportMouseEvent& event)
+void InteractiveMarkerControl::moveViewPlane(Ogre::Ray& mouse_ray, const rviz_common::ViewportMouseEvent& event)
 {
   // find plane on which mouse is moving
   Ogre::Plane plane(event.viewport->getCamera()->getRealDirection(), grab_point_in_reference_frame_);
@@ -591,8 +590,8 @@ void InteractiveMarkerControl::worldToScreen(const Ogre::Vector3& pos_rel_refere
   const Ogre::Camera* cam = viewport->getCamera();
   Ogre::Vector3 homogeneous_screen_position = cam->getProjectionMatrix() * (cam->getViewMatrix() * world_pos);
 
-  Ogre::Real half_width = static_cast<Ogre::Real>(viewport->getActualWidth()) / 2.0f;
-  Ogre::Real half_height = static_cast<Ogre::Real>(viewport->getActualHeight()) / 2.0f;
+  double half_width = viewport->getActualWidth() / 2.0;
+  double half_height = viewport->getActualHeight() / 2.0;
 
   screen_pos.x = half_width + (half_width * homogeneous_screen_position.x) - 0.5f;
   screen_pos.y = half_height + (half_height * -homogeneous_screen_position.y) - 0.5f;
@@ -614,25 +613,25 @@ bool InteractiveMarkerControl::findClosestPoint(const Ogre::Ray& target_ray,
   Ogre::Vector3 v13 = target_ray.getOrigin() - mouse_ray.getOrigin();
   Ogre::Vector3 v43 = mouse_ray.getDirection();
   Ogre::Vector3 v21 = target_ray.getDirection();
-  Ogre::Real d1343 = v13.dotProduct(v43);
-  Ogre::Real d4321 = v43.dotProduct(v21);
-  Ogre::Real d1321 = v13.dotProduct(v21);
-  Ogre::Real d4343 = v43.dotProduct(v43);
-  Ogre::Real d2121 = v21.dotProduct(v21);
+  double d1343 = v13.dotProduct(v43);
+  double d4321 = v43.dotProduct(v21);
+  double d1321 = v13.dotProduct(v21);
+  double d4343 = v43.dotProduct(v43);
+  double d2121 = v21.dotProduct(v21);
 
-  Ogre::Real denom = d2121 * d4343 - d4321 * d4321;
+  double denom = d2121 * d4343 - d4321 * d4321;
   if (fabs(denom) <= Ogre::Matrix3::EPSILON)
   {
     return false;
   }
-  Ogre::Real numer = d1343 * d4321 - d1321 * d4343;
+  double numer = d1343 * d4321 - d1321 * d4343;
 
-  Ogre::Real mua = numer / denom;
+  double mua = numer / denom;
   closest_point = target_ray.getPoint(mua);
   return true;
 }
 
-void InteractiveMarkerControl::moveAxis(const Ogre::Ray& /*mouse_ray*/, const rviz::ViewportMouseEvent& event)
+void InteractiveMarkerControl::moveAxis(const Ogre::Ray& mouse_ray, const rviz_common::ViewportMouseEvent& event)
 {
   // compute control-axis ray based on grab_point_, etc.
   Ogre::Ray control_ray;
@@ -641,10 +640,11 @@ void InteractiveMarkerControl::moveAxis(const Ogre::Ray& /*mouse_ray*/, const rv
 
   // project control-axis ray onto screen.
   Ogre::Vector2 control_ray_screen_start, control_ray_screen_end;
-  worldToScreen(control_ray.getOrigin(), event.viewport, control_ray_screen_start);
-  worldToScreen(control_ray.getPoint(1), event.viewport, control_ray_screen_end);
+  // TODO: Fix for ROS 2
+//  worldToScreen(control_ray.getOrigin(), event.viewport, control_ray_screen_start);
+//  worldToScreen(control_ray.getPoint(1), event.viewport, control_ray_screen_end);
 
-  Ogre::Vector2 mouse_point(static_cast<Ogre::Real>(event.x), static_cast<Ogre::Real>(event.y));
+  Ogre::Vector2 mouse_point(event.x, event.y);
 
   // Find closest point on projected ray to mouse point
   // Math: if P is the start of the ray, v is the direction vector of
@@ -656,16 +656,15 @@ void InteractiveMarkerControl::moveAxis(const Ogre::Ray& /*mouse_ray*/, const rv
   //                 v.v
   //       where "." is the dot product.
   Ogre::Vector2 control_ray_screen_dir = control_ray_screen_end - control_ray_screen_start;
-  Ogre::Real denominator = control_ray_screen_dir.dotProduct(control_ray_screen_dir);
+  double denominator = control_ray_screen_dir.dotProduct(control_ray_screen_dir);
   if (fabs(denominator) > Ogre::Matrix3::EPSILON)  // If the control ray is not straight in line with the view.
   {
-    Ogre::Real factor = (mouse_point - control_ray_screen_start).dotProduct(control_ray_screen_dir) / denominator;
+    double factor = (mouse_point - control_ray_screen_start).dotProduct(control_ray_screen_dir) / denominator;
 
     Ogre::Vector2 closest_screen_point = control_ray_screen_start + control_ray_screen_dir * factor;
 
     // make a new "mouse ray" for the point on the projected ray
-    Ogre::Ray new_mouse_ray = getMouseRayInReferenceFrame(
-        event, static_cast<int>(closest_screen_point.x), static_cast<int>(closest_screen_point.y));
+    Ogre::Ray new_mouse_ray = getMouseRayInReferenceFrame(event, closest_screen_point.x, closest_screen_point.y);
 
     // find closest point on control-axis ray to new mouse ray (should intersect actually)
     Ogre::Vector3 closest_point;
@@ -749,7 +748,7 @@ void InteractiveMarkerControl::moveRotate(Ogre::Ray& mouse_ray)
       // compute translation from rotated old drag point to new drag point.
       //  - pos_change = new_rel_center * (1.0 - prev_rel_center.length() / new_rel_center.length())
       //  - parent_->translate(pos_change)
-      parent_->translate(new_rel_center * (1.0f - prev_rel_center.length() / new_rel_center.length()), name_);
+      parent_->translate(new_rel_center * (1.0 - prev_rel_center.length() / new_rel_center.length()), name_);
     }
   }
 }
@@ -813,7 +812,7 @@ void InteractiveMarkerControl::moveRotate(const Ogre::Vector3& cursor_position_i
     // compute translation from rotated old drag point to new drag point.
     //  - pos_change = new_rel_center * (1.0 - prev_rel_center.length() / new_rel_center.length())
     //  - parent_->translate(pos_change)
-    parent_->translate(new_rel_center * (1.0f - prev_rel_center.length() / new_rel_center.length()), name_);
+    parent_->translate(new_rel_center * (1.0 - prev_rel_center.length() / new_rel_center.length()), name_);
   }
 }
 
@@ -848,7 +847,7 @@ void InteractiveMarkerControl::move3D(const Ogre::Vector3& cursor_position_in_re
   parent_->setPose(marker_position_in_reference_frame, parent_->getOrientation(), name_);
 }
 
-void InteractiveMarkerControl::rotate3D(const Ogre::Vector3& /*cursor_position_in_reference_frame*/,
+void InteractiveMarkerControl::rotate3D(const Ogre::Vector3& cursor_position_in_reference_frame,
                                         const Ogre::Quaternion& cursor_orientation_in_reference_frame)
 {
   if (orientation_mode_ == OrientationMode::VIEW_FACING && drag_viewport_)
@@ -860,19 +859,19 @@ void InteractiveMarkerControl::rotate3D(const Ogre::Vector3& /*cursor_position_i
   // parent_->getPosition()); rotation_cursor_to_parent_at_grab_ =
   // cursor_3D_orientation.Inverse()*parent->getOrientation();
 
-  //  Ogre::Vector3 world_to_cursor_in_world_frame =
-  //      reference_node_->convertLocalToWorldPosition(cursor_position_in_reference_frame);
+  Ogre::Vector3 world_to_cursor_in_world_frame =
+      reference_node_->convertLocalToWorldPosition(cursor_position_in_reference_frame);
   Ogre::Quaternion rotation_world_to_cursor =
       reference_node_->convertLocalToWorldOrientation(cursor_orientation_in_reference_frame);
 
   // Ogre::Vector3 marker_to_cursor_in_cursor_frame =
   // orientation_world_to_cursor.Inverse()*reference_node_->getOrientation()*grab_point_in_reference_frame_;
 
-  //  Ogre::Vector3 world_to_cursor_in_cursor_frame = rotation_world_to_cursor.Inverse() *
-  //  world_to_cursor_in_world_frame; Ogre::Vector3 world_to_marker_in_world_frame =
-  //      rotation_world_to_cursor * (world_to_cursor_in_cursor_frame - parent_to_cursor_in_cursor_frame_at_grab_);
-  //  Ogre::Vector3 marker_position_in_reference_frame =
-  //      reference_node_->convertWorldToLocalPosition(world_to_marker_in_world_frame);
+  Ogre::Vector3 world_to_cursor_in_cursor_frame = rotation_world_to_cursor.Inverse() * world_to_cursor_in_world_frame;
+  Ogre::Vector3 world_to_marker_in_world_frame =
+      rotation_world_to_cursor * (world_to_cursor_in_cursor_frame - parent_to_cursor_in_cursor_frame_at_grab_);
+  Ogre::Vector3 marker_position_in_reference_frame =
+      reference_node_->convertWorldToLocalPosition(world_to_marker_in_world_frame);
   Ogre::Quaternion marker_orientation_in_reference_frame =
       reference_node_->convertWorldToLocalOrientation(rotation_world_to_cursor * rotation_cursor_to_parent_at_grab_);
 
@@ -935,7 +934,7 @@ void InteractiveMarkerControl::setHighlight(float a)
   //  }
 }
 
-void InteractiveMarkerControl::recordDraggingInPlaceEvent(rviz::ViewportMouseEvent& event)
+void InteractiveMarkerControl::recordDraggingInPlaceEvent(rviz_common::ViewportMouseEvent& event)
 {
   dragging_in_place_event_ = event;
   dragging_in_place_event_.type = QEvent::MouseMove;
@@ -951,13 +950,13 @@ void InteractiveMarkerControl::stopDragging(bool force)
   {
     //    line_->setVisible(false);
     mouse_dragging_ = false;
-    drag_viewport_ = nullptr;
+    drag_viewport_ = NULL;
     parent_->stopDragging();
   }
 }
 
 // Almost a wholesale copy of the mouse event code... can these be combined?
-void InteractiveMarkerControl::handle3DCursorEvent(rviz::ViewportMouseEvent event,
+void InteractiveMarkerControl::handle3DCursorEvent(rviz_common::ViewportMouseEvent event,
                                                    const Ogre::Vector3& cursor_3D_pos,
                                                    const Ogre::Quaternion& cursor_3D_orientation)
 {
@@ -967,8 +966,8 @@ void InteractiveMarkerControl::handle3DCursorEvent(rviz::ViewportMouseEvent even
     case InteractiveMode::BUTTON:
       if (event.leftUp())
       {
-        //        Ogre::Vector3 point_rel_world = cursor_3D_pos;
-        //        bool got_3D_point = true;
+        Ogre::Vector3 point_rel_world = cursor_3D_pos;
+        bool got_3D_point = true;
 
         //      visualization_msgs::InteractiveMarkerFeedback feedback;
         //      feedback.event_type = visualization_msgs::InteractiveMarkerFeedback::BUTTON_CLICK;
@@ -984,8 +983,8 @@ void InteractiveMarkerControl::handle3DCursorEvent(rviz::ViewportMouseEvent even
         // Save the 3D mouse point to send with the menu feedback, if any.
         Ogre::Vector3 three_d_point = cursor_3D_pos;
         bool valid_point = true;
-        Ogre::Vector2 mouse_pos = rviz::project3DPointToViewportXY(event.viewport, three_d_point);
-        QCursor::setPos(event.panel->mapToGlobal(QPoint(static_cast<int>(mouse_pos.x), static_cast<int>(mouse_pos.y))));
+        Ogre::Vector2 mouse_pos = rviz_common::project3DPointToViewportXY(event.viewport, three_d_point);
+        QCursor::setPos(event.panel->mapToGlobal(QPoint(mouse_pos.x, mouse_pos.y)));
         parent_->showMenu(event, name_, three_d_point, valid_point);
       }
       break;
@@ -1099,7 +1098,7 @@ void InteractiveMarkerControl::handle3DCursorEvent(rviz::ViewportMouseEvent even
   }
 }
 
-void InteractiveMarkerControl::handleMouseEvent(rviz::ViewportMouseEvent& event)
+void InteractiveMarkerControl::handleMouseEvent(rviz_common::ViewportMouseEvent& event)
 {
   // REMOVE ME ROS_INFO("Mouse event!");
   // * check if this is just a receive/lost focus event
@@ -1130,9 +1129,9 @@ void InteractiveMarkerControl::handleMouseEvent(rviz::ViewportMouseEvent& event)
     case InteractiveMode::BUTTON:
       if (event.leftUp())
       {
-        //        Ogre::Vector3 point_rel_world;
-        //        bool got_3D_point =
-        //            context_->getSelectionManager()->get3DPoint(event.viewport, event.x, event.y, point_rel_world);
+        Ogre::Vector3 point_rel_world;
+        bool got_3D_point =
+            context_->getSelectionManager()->get3DPoint(event.viewport, event.x, event.y, point_rel_world);
 
         //      visualization_msgs::InteractiveMarkerFeedback feedback;
         //      feedback.event_type = visualization_msgs::InteractiveMarkerFeedback::BUTTON_CLICK;
@@ -1209,7 +1208,7 @@ void InteractiveMarkerControl::handleMouseEvent(rviz::ViewportMouseEvent& event)
   }
 }
 
-void InteractiveMarkerControl::beginMouseMovement(rviz::ViewportMouseEvent& event, bool /*line_visible*/)
+void InteractiveMarkerControl::beginMouseMovement(rviz_common::ViewportMouseEvent& event, bool line_visible)
 {
   //  line_->setVisible(line_visible);
 
@@ -1259,7 +1258,7 @@ void InteractiveMarkerControl::beginMouseMovement(rviz::ViewportMouseEvent& even
   grab_point_rel_control_ = reference_rel_control_frame * grab_point_in_reference_frame_;
 
   // find mouse_z_scale_
-  static const Ogre::Real DEFAULT_MOUSE_Z_SCALE = 0.001f;  // default to 1mm per pixel
+  static const double DEFAULT_MOUSE_Z_SCALE = 0.001;  // default to 1mm per pixel
   mouse_z_scale_ = DEFAULT_MOUSE_Z_SCALE;
 
   Ogre::Ray mouse_ray = getMouseRayInReferenceFrame(event, event.x, event.y);
@@ -1268,7 +1267,7 @@ void InteractiveMarkerControl::beginMouseMovement(rviz::ViewportMouseEvent& even
   Ogre::Vector3 intersection_3d;
   Ogre::Vector3 intersection_3d_10;
   Ogre::Vector2 intersection_2d;
-  Ogre::Real ray_t;
+  float ray_t;
 
   if (intersectSomeYzPlane(mouse_ray,
                            grab_point_in_reference_frame_,
@@ -1285,13 +1284,13 @@ void InteractiveMarkerControl::beginMouseMovement(rviz::ViewportMouseEvent& even
                              ray_t))
     {
       mouse_z_scale_ = (intersection_3d_10 - intersection_3d).length() / 10.0f;
-      if (mouse_z_scale_ < std::numeric_limits<Ogre::Real>::min() * 100.0f)
+      if (mouse_z_scale_ < std::numeric_limits<float>::min() * 100.0f)
         mouse_z_scale_ = DEFAULT_MOUSE_Z_SCALE;
     }
   }
 }
 
-void InteractiveMarkerControl::handleMouseMovement(rviz::ViewportMouseEvent& event)
+void InteractiveMarkerControl::handleMouseMovement(rviz_common::ViewportMouseEvent& event)
 {
   Ogre::Ray mouse_ray = getMouseRayInReferenceFrame(event, event.x, event.y);
 
@@ -1317,12 +1316,10 @@ void InteractiveMarkerControl::handleMouseMovement(rviz::ViewportMouseEvent& eve
     case InteractiveMode::ROTATE_3D:
       do_rotation = true;
       // fall through
-      BOOST_FALLTHROUGH;
     case InteractiveMode::MOVE_ROTATE_3D:
       if (event.control())
         do_rotation = true;
       // fall through
-      BOOST_FALLTHROUGH;
     case InteractiveMode::MOVE_3D:
       if (do_rotation)
       {
@@ -1345,7 +1342,7 @@ void InteractiveMarkerControl::handleMouseMovement(rviz::ViewportMouseEvent& eve
   }
 }
 
-void InteractiveMarkerControl::handleMouseWheelMovement(rviz::ViewportMouseEvent& event)
+void InteractiveMarkerControl::handleMouseWheelMovement(rviz_common::ViewportMouseEvent& event)
 {
   switch (interaction_mode_)
   {
@@ -1402,10 +1399,11 @@ bool InteractiveMarkerControl::intersectSomeYzPlane(const Ogre::Ray& mouse_ray,
   return false;
 }
 
-void InteractiveMarkerControl::addHighlightPass(const std::set<Ogre::MaterialPtr>& materials)
+void InteractiveMarkerControl::addHighlightPass(std::set<Ogre::MaterialPtr> materials)
 {
-  for (const auto& material : materials)
+  for (auto it = materials.begin(); it != materials.end(); it++)
   {
+    Ogre::MaterialPtr material = *it;
     Ogre::Pass* original_pass = material->getTechnique(0)->getPass(0);
     Ogre::Pass* pass = material->getTechnique(0)->createPass();
 

--- a/tesseract_rviz/src/markers/arrow_marker.cpp
+++ b/tesseract_rviz/src/markers/arrow_marker.cpp
@@ -33,10 +33,10 @@
 #include <OgreSceneManager.h>
 #include <OgreEntity.h>
 
-#include "rviz/display_context.h"
-#include "rviz/ogre_helpers/arrow.h"
-#include "rviz/ogre_helpers/shape.h"
-#include "rviz/selection/selection_manager.h"
+#include "rviz_common/display_context.hpp"
+#include "rviz_rendering/objects/arrow.hpp"
+#include "rviz_rendering/objects/shape.hpp"
+#include "rviz_common/interaction/selection_manager.hpp"
 
 #include <tesseract_rviz/markers/arrow_marker.h>
 #include <tesseract_rviz/markers/marker_selection_handler.h>
@@ -45,13 +45,13 @@ namespace tesseract_rviz
 {
 ArrowMarker::ArrowMarker(const std::string& ns,
                          const int id,
-                         rviz::DisplayContext* context,
+                         rviz_common::DisplayContext* context,
                          Ogre::SceneNode* parent_node)
   : MarkerBase(ns, id, context, parent_node), arrow_(nullptr), location_(Ogre::Vector3(0, 0, 0))
 {
   child_scene_node_ = scene_node_->createChildSceneNode();
 
-  arrow_ = new rviz::Arrow(context_->getSceneManager(), child_scene_node_);
+  arrow_ = new rviz_rendering::Arrow(context_->getSceneManager(), child_scene_node_);
   setDefaultProportions();
   handler_.reset(new MarkerSelectionHandler(this, MarkerID(ns, id), context_));
   handler_->addTrackedObjects(arrow_->getSceneNode());
@@ -64,14 +64,14 @@ ArrowMarker::ArrowMarker(const std::string& ns,
                          const int id,
                          Ogre::Vector3 point1,
                          Ogre::Vector3 point2,
-                         rviz::DisplayContext* context,
+                         rviz_common::DisplayContext* context,
                          Ogre::SceneNode* parent_node)
   : MarkerBase(ns, id, context, parent_node), arrow_(nullptr)
 {
   child_scene_node_ = scene_node_->createChildSceneNode();
   location_ = point1;
 
-  arrow_ = new rviz::Arrow(context_->getSceneManager(), child_scene_node_);
+  arrow_ = new rviz_rendering::Arrow(context_->getSceneManager(), child_scene_node_);
   setDefaultProportions();
   handler_.reset(new MarkerSelectionHandler(this, MarkerID(ns, id), context_));
   handler_->addTrackedObjects(arrow_->getSceneNode());

--- a/tesseract_rviz/src/markers/cube_marker.cpp
+++ b/tesseract_rviz/src/markers/cube_marker.cpp
@@ -27,10 +27,10 @@
 #include <tesseract_rviz/markers/marker_selection_handler.h>
 #include <tesseract_rviz/markers/utils.h>
 
-#include <rviz/display_context.h>
-#include <rviz/selection/selection_manager.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/interaction/selection_manager.hpp>
 
-#include <rviz/ogre_helpers/shape.h>
+#include <rviz_rendering/objects/shape.hpp>
 
 #include <OgreSceneNode.h>
 #include <OgreMatrix3.h>
@@ -39,12 +39,12 @@ namespace tesseract_rviz
 {
 CubeMarker::CubeMarker(const std::string& ns,
                        const int id,
-                       rviz::DisplayContext* context,
+                       rviz_common::DisplayContext* context,
                        Ogre::SceneNode* parent_node,
                        float size)
   : MarkerBase(ns, id, context, parent_node), shape_(nullptr), scale_(Ogre::Vector3(1, 1, 1)), size_(size)
 {
-  shape_ = new rviz::Shape(rviz::Shape::Cube, context_->getSceneManager(), scene_node_);
+  shape_ = new rviz_rendering::Shape(rviz_rendering::Shape::Cube, context_->getSceneManager(), scene_node_);
   setScale(scale_);
 
   handler_.reset(new MarkerSelectionHandler(this, MarkerID(ns_, id_), context_));

--- a/tesseract_rviz/src/markers/cylinder_marker.cpp
+++ b/tesseract_rviz/src/markers/cylinder_marker.cpp
@@ -27,10 +27,10 @@
 #include <tesseract_rviz/markers/marker_selection_handler.h>
 #include <tesseract_rviz/markers/utils.h>
 
-#include <rviz/display_context.h>
-#include <rviz/selection/selection_manager.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/interaction/selection_manager.hpp>
 
-#include <rviz/ogre_helpers/shape.h>
+#include <rviz_rendering/objects/shape.hpp>
 
 #include <OgreSceneNode.h>
 #include <OgreMatrix3.h>
@@ -39,7 +39,7 @@ namespace tesseract_rviz
 {
 CylinderMarker::CylinderMarker(const std::string& ns,
                                const int id,
-                               rviz::DisplayContext* context,
+                               rviz_common::DisplayContext* context,
                                Ogre::SceneNode* parent_node,
                                float radius,
                                float height)
@@ -49,7 +49,7 @@ CylinderMarker::CylinderMarker(const std::string& ns,
   , radius_(radius)
   , height_(height)
 {
-  shape_ = new rviz::Shape(rviz::Shape::Cylinder, context_->getSceneManager(), scene_node_);
+  shape_ = new rviz_rendering::Shape(rviz_rendering::Shape::Cylinder, context_->getSceneManager(), scene_node_);
   setScale(scale_);
 
   handler_.reset(new MarkerSelectionHandler(this, MarkerID(ns_, id_), context_));

--- a/tesseract_rviz/src/markers/marker_base.cpp
+++ b/tesseract_rviz/src/markers/marker_base.cpp
@@ -43,18 +43,18 @@
 
 namespace tesseract_rviz
 {
-MarkerBase::MarkerBase(const std::string& ns, const int id, rviz_common::DisplayContext* context, Ogre::SceneNode* parent_node)
-  : ns_(ns), id_(id), context_(context), scene_node_(parent_node->createChildSceneNode())
+MarkerBase::MarkerBase(std::string ns, const int id, rviz_common::DisplayContext* context, Ogre::SceneNode* parent_node)
+  : ns_(std::move(ns)), id_(id), context_(context), scene_node_(parent_node->createChildSceneNode())
 {
 }
 
 MarkerBase::~MarkerBase() { context_->getSceneManager()->destroySceneNode(scene_node_); }
 
-void MarkerBase::setInteractiveObject(rviz_common::InteractiveObjectWPtr control)
+void MarkerBase::setInteractiveObject(rviz_common::InteractiveObjectWPtr object)
 {
   if (handler_)
   {
-    handler_->setInteractiveObject(control);
+    handler_->setInteractiveObject(std::move(object));
   }
 }
 
@@ -72,7 +72,7 @@ void MarkerBase::extractMaterials(Ogre::Entity* entity, std::set<Ogre::MaterialP
   for (uint32_t i = 0; i < num_sub_entities; ++i)
   {
     Ogre::SubEntity* sub = entity->getSubEntity(i);
-    Ogre::MaterialPtr material = sub->getMaterial();
+    const Ogre::MaterialPtr& material = sub->getMaterial();
     materials.insert(material);
   }
 }

--- a/tesseract_rviz/src/markers/marker_base.cpp
+++ b/tesseract_rviz/src/markers/marker_base.cpp
@@ -30,10 +30,10 @@
 #include "tesseract_rviz/markers/marker_base.h"
 #include <tesseract_rviz/markers/marker_selection_handler.h>
 
-#include <rviz/display_context.h>
-#include <rviz/selection/selection_manager.h>
-#include <rviz/frame_manager.h>
-#include <rviz/interactive_object.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/interaction/selection_manager.hpp>
+#include <rviz_common/frame_manager_iface.hpp>
+#include <rviz_common/interactive_object.hpp>
 
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
@@ -43,18 +43,18 @@
 
 namespace tesseract_rviz
 {
-MarkerBase::MarkerBase(std::string ns, const int id, rviz::DisplayContext* context, Ogre::SceneNode* parent_node)
-  : ns_(std::move(ns)), id_(id), context_(context), scene_node_(parent_node->createChildSceneNode())
+MarkerBase::MarkerBase(const std::string& ns, const int id, rviz_common::DisplayContext* context, Ogre::SceneNode* parent_node)
+  : ns_(ns), id_(id), context_(context), scene_node_(parent_node->createChildSceneNode())
 {
 }
 
 MarkerBase::~MarkerBase() { context_->getSceneManager()->destroySceneNode(scene_node_); }
 
-void MarkerBase::setInteractiveObject(rviz::InteractiveObjectWPtr object)
+void MarkerBase::setInteractiveObject(rviz_common::InteractiveObjectWPtr control)
 {
   if (handler_)
   {
-    handler_->setInteractiveObject(std::move(object));
+    handler_->setInteractiveObject(control);
   }
 }
 
@@ -72,7 +72,7 @@ void MarkerBase::extractMaterials(Ogre::Entity* entity, std::set<Ogre::MaterialP
   for (uint32_t i = 0; i < num_sub_entities; ++i)
   {
     Ogre::SubEntity* sub = entity->getSubEntity(i);
-    const Ogre::MaterialPtr& material = sub->getMaterial();
+    Ogre::MaterialPtr material = sub->getMaterial();
     materials.insert(material);
   }
 }

--- a/tesseract_rviz/src/markers/marker_selection_handler.cpp
+++ b/tesseract_rviz/src/markers/marker_selection_handler.cpp
@@ -32,11 +32,11 @@
 
 #include <tesseract_rviz/markers/marker_selection_handler.h>
 #include <tesseract_rviz/markers/marker_base.h>
-#include <tesseract_rviz/interactive_marker/interactive_marker_control.h>
+//#include <tesseract_rviz/interactive_marker/interactive_marker_control.h>
 
 namespace tesseract_rviz
 {
-MarkerSelectionHandler::MarkerSelectionHandler(const MarkerBase* marker, MarkerID id, rviz::DisplayContext* context)
+MarkerSelectionHandler::MarkerSelectionHandler(const MarkerBase* marker, MarkerID id, rviz_common::DisplayContext* context)
   : SelectionHandler(context)
   , marker_(marker)
   , marker_id_(QString::fromStdString(id.first) + "/" + QString::number(id.second))

--- a/tesseract_rviz/src/markers/marker_selection_handler.cpp
+++ b/tesseract_rviz/src/markers/marker_selection_handler.cpp
@@ -32,7 +32,7 @@
 
 #include <tesseract_rviz/markers/marker_selection_handler.h>
 #include <tesseract_rviz/markers/marker_base.h>
-//#include <tesseract_rviz/interactive_marker/interactive_marker_control.h>
+#include <tesseract_rviz/interactive_marker/interactive_marker_control.h>
 
 namespace tesseract_rviz
 {

--- a/tesseract_rviz/src/markers/sphere_marker.cpp
+++ b/tesseract_rviz/src/markers/sphere_marker.cpp
@@ -27,10 +27,10 @@
 #include <tesseract_rviz/markers/marker_selection_handler.h>
 #include <tesseract_rviz/markers/utils.h>
 
-#include <rviz/display_context.h>
-#include <rviz/selection/selection_manager.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/interaction/selection_manager.hpp>
 
-#include <rviz/ogre_helpers/shape.h>
+#include <rviz_rendering/objects/shape.hpp>
 
 #include <OgreSceneNode.h>
 #include <OgreMatrix3.h>
@@ -39,12 +39,12 @@ namespace tesseract_rviz
 {
 SphereMarker::SphereMarker(const std::string& ns,
                            const int id,
-                           rviz::DisplayContext* context,
+                           rviz_common::DisplayContext* context,
                            Ogre::SceneNode* parent_node,
                            float radius)
   : MarkerBase(ns, id, context, parent_node), shape_(nullptr), scale_(Ogre::Vector3(1, 1, 1)), radius_(radius)
 {
-  shape_ = new rviz::Shape(rviz::Shape::Sphere, context_->getSceneManager(), scene_node_);
+  shape_ = new rviz_rendering::Shape(rviz_rendering::Shape::Sphere, context_->getSceneManager(), scene_node_);
   setScale(scale_);
 
   handler_.reset(new MarkerSelectionHandler(this, MarkerID(ns_, id_), context_));

--- a/tesseract_rviz/src/markers/text_view_facing_marker.cpp
+++ b/tesseract_rviz/src/markers/text_view_facing_marker.cpp
@@ -30,11 +30,9 @@
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 
-#include <ros/assert.h>
-
-#include "rviz/display_context.h"
-#include "rviz/ogre_helpers/movable_text.h"
-#include "rviz/selection/selection_manager.h"
+#include "rviz_common/display_context.hpp"
+#include "rviz_rendering/objects/movable_text.hpp"
+#include "rviz_common/interaction/selection_manager.hpp"
 
 #include <tesseract_rviz/markers/marker_selection_handler.h>
 #include <tesseract_rviz/markers/text_view_facing_marker.h>
@@ -44,13 +42,13 @@ namespace tesseract_rviz
 TextViewFacingMarker::TextViewFacingMarker(const std::string& ns,
                                            const int id,
                                            const std::string& caption,
-                                           rviz::DisplayContext* context,
+                                           rviz_common::DisplayContext* context,
                                            Ogre::SceneNode* parent_node)
 
   : MarkerBase(ns, id, context, parent_node), text_(nullptr)
 {
-  text_ = new rviz::MovableText(caption);
-  text_->setTextAlignment(rviz::MovableText::H_CENTER, rviz::MovableText::V_CENTER);
+  text_ = new rviz_rendering::MovableText(caption);
+  text_->setTextAlignment(rviz_rendering::MovableText::H_CENTER, rviz_rendering::MovableText::V_CENTER);
   text_->setCharacterHeight(0.15f);
   scene_node_->attachObject(text_);
 

--- a/tesseract_rviz/src/markers/triangle_list_marker.cpp
+++ b/tesseract_rviz/src/markers/triangle_list_marker.cpp
@@ -43,7 +43,6 @@
 
 #include <tesseract_rviz/markers/triangle_list_marker.h>
 #include <tesseract_rviz/markers/marker_selection_handler.h>
-#include <console_bridge/console.h>
 
 namespace tesseract_rviz
 {
@@ -82,7 +81,7 @@ TriangleListMarker::TriangleListMarker(const std::string& ns,
       ss << "TriMesh marker [" << getStringID() << "] has a point count which is not divisible by 3 [" << num_points
          << "]";
     }
-    CONSOLE_BRIDGE_logDebug("%s", ss.str().c_str());
+    //ROS_DEBUG("%s", ss.str().c_str());
 
     scene_node_->setVisible(false);
     return;

--- a/tesseract_rviz/src/markers/triangle_list_marker.cpp
+++ b/tesseract_rviz/src/markers/triangle_list_marker.cpp
@@ -27,12 +27,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "rviz/default_plugin/marker_display.h"
-#include "rviz/selection/selection_manager.h"
-#include "rviz/uniform_string_stream.h"
+#include "rviz_default_plugins/displays/marker/marker_display.hpp"
+#include "rviz_common/interaction/selection_manager.hpp"
+#include "rviz_common/uniform_string_stream.hpp"
 
-#include "rviz/display_context.h"
-#include "rviz/mesh_loader.h"
+#include "rviz_common/display_context.hpp"
+#include "rviz_rendering/mesh_loader.hpp"
 
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
@@ -43,6 +43,7 @@
 
 #include <tesseract_rviz/markers/triangle_list_marker.h>
 #include <tesseract_rviz/markers/marker_selection_handler.h>
+#include <console_bridge/console.h>
 
 namespace tesseract_rviz
 {
@@ -57,7 +58,7 @@ const std::string GROUP_NAME = "rviz";
 
 TriangleListMarker::TriangleListMarker(const std::string& ns,
                                        const int id,
-                                       rviz::DisplayContext* context,
+                                       rviz_common::DisplayContext* context,
                                        Ogre::SceneNode* parent_node,
                                        const Ogre::ColourValue color,
                                        const std::vector<Ogre::Vector3>& points,
@@ -81,7 +82,7 @@ TriangleListMarker::TriangleListMarker(const std::string& ns,
       ss << "TriMesh marker [" << getStringID() << "] has a point count which is not divisible by 3 [" << num_points
          << "]";
     }
-    ROS_DEBUG("%s", ss.str().c_str());
+    CONSOLE_BRIDGE_logDebug("%s", ss.str().c_str());
 
     scene_node_->setVisible(false);
     return;

--- a/tesseract_rviz/src/markers/triangle_list_marker.cpp
+++ b/tesseract_rviz/src/markers/triangle_list_marker.cpp
@@ -49,12 +49,6 @@ namespace tesseract_rviz
 static Ogre::NameGenerator tringle_list_generator("Tesseract_Triangle_List");
 static Ogre::NameGenerator material_name_generator("Tesseract_Triangle_List_Material");
 
-#ifdef noetic_BUILD
-const std::string GROUP_NAME = Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME;
-#else
-const std::string GROUP_NAME = "rviz";
-#endif
-
 TriangleListMarker::TriangleListMarker(const std::string& ns,
                                        const int id,
                                        rviz_common::DisplayContext* context,
@@ -95,7 +89,8 @@ TriangleListMarker::TriangleListMarker(const std::string& ns,
     scene_node_->attachObject(manual_object_);
 
     material_name_ = material_name_generator.generate();
-    material_ = Ogre::MaterialManager::getSingleton().create(material_name_, GROUP_NAME);
+    material_ = Ogre::MaterialManager::getSingleton().create(material_name_,
+        Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     material_->setReceiveShadows(false);
     material_->getTechnique(0)->setLightingEnabled(true);
     material_->setCullingMode(Ogre::CULL_NONE);

--- a/tesseract_rviz/src/markers/utils.cpp
+++ b/tesseract_rviz/src/markers/utils.cpp
@@ -35,8 +35,8 @@
 #include <tesseract_rviz/interactive_marker/interactive_marker.h>
 #include <tesseract_rviz/interactive_marker/interactive_marker_control.h>
 
-#include <rviz/display_context.h>
-#include <rviz/ogre_helpers/shape.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_rendering/objects/shape.hpp>
 
 #include <boost/make_shared.hpp>
 
@@ -44,7 +44,7 @@ namespace tesseract_rviz
 {
 void makeSphere(InteractiveMarkerControl& control, float radius)
 {
-  SphereMarker::Ptr marker = boost::make_shared<SphereMarker>(
+  SphereMarker::SharedPtr marker = boost::make_shared<SphereMarker>(
       control.getName(), 0, control.getDisplayContext(), control.getMarkerSceneNode(), radius);
   marker->setScale(Ogre::Vector3(control.getSize(), control.getSize(), control.getSize()));
   marker->setColor(Ogre::ColourValue(1.0f, 1.0f, 0.0f, 0.5f));
@@ -74,7 +74,7 @@ void makeArrow(InteractiveMarkerControl& control, float pos)
   point2.y = 0;
   point2.z = 0;
 
-  ArrowMarker::Ptr marker = boost::make_shared<ArrowMarker>(
+  ArrowMarker::SharedPtr marker = boost::make_shared<ArrowMarker>(
       control.getName(), 0, point1, point2, control.getDisplayContext(), control.getMarkerSceneNode());
   marker->setColor(default_color);
   marker->setOrientation(control.getControlOrientation());
@@ -86,7 +86,7 @@ void makeArrow(InteractiveMarkerControl& control, float pos)
 void makeTitle(InteractiveMarkerControl& control, const std::string& text)
 {
   Ogre::ColourValue default_color(1, 1, 1, 1);
-  TextViewFacingMarker::Ptr marker = boost::make_shared<TextViewFacingMarker>(
+  TextViewFacingMarker::SharedPtr marker = boost::make_shared<TextViewFacingMarker>(
       control.getName(), 0, text, control.getDisplayContext(), control.getMarkerSceneNode());
   marker->setColor(default_color);
   float scale = control.getSize();
@@ -224,7 +224,7 @@ void makeDisc(InteractiveMarkerControl& control, float width)
       break;
   }
 
-  TriangleListMarker::Ptr marker = boost::make_shared<TriangleListMarker>(
+  TriangleListMarker::SharedPtr marker = boost::make_shared<TriangleListMarker>(
       control.getName(), 0, control.getDisplayContext(), control.getMarkerSceneNode(), default_color, points, colors);
   marker->setOrientation(control.getControlOrientation());
   float scale = control.getSize();
@@ -260,7 +260,7 @@ void makeDisc(InteractiveMarkerControl& control, float width)
 
 void make6Dof(InteractiveMarker& interactive_marker)
 {
-  InteractiveMarkerControl::Ptr control = interactive_marker.createInteractiveControl("move_rotate_3d",
+  InteractiveMarkerControl::SharedPtr control = interactive_marker.createInteractiveControl("move_rotate_3d",
                                                                                       "Move Rotate 3D",
                                                                                       InteractiveMode::MOVE_ROTATE_3D,
                                                                                       OrientationMode::INHERIT,
@@ -268,7 +268,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
                                                                                       Ogre::Quaternion(1, 0, 0, 0));
   makeSphere(*control, 0.5f);
 
-  InteractiveMarkerControl::Ptr control1 = interactive_marker.createInteractiveControl("move_x",
+  InteractiveMarkerControl::SharedPtr control1 = interactive_marker.createInteractiveControl("move_x",
                                                                                        "Move along X Axis",
                                                                                        InteractiveMode::MOVE_AXIS,
                                                                                        OrientationMode::INHERIT,
@@ -277,7 +277,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
   makeArrow(*control1, 0.5);
   makeArrow(*control1, -0.5);
 
-  InteractiveMarkerControl::Ptr control4 = interactive_marker.createInteractiveControl("rotate_x",
+  InteractiveMarkerControl::SharedPtr control4 = interactive_marker.createInteractiveControl("rotate_x",
                                                                                        "Rotate around X Axis",
                                                                                        InteractiveMode::ROTATE_AXIS,
                                                                                        OrientationMode::INHERIT,
@@ -285,7 +285,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
                                                                                        Ogre::Quaternion(1, 1, 0, 0));
   makeDisc(*control4, 0.3f);
 
-  InteractiveMarkerControl::Ptr control2 = interactive_marker.createInteractiveControl("move_y",
+  InteractiveMarkerControl::SharedPtr control2 = interactive_marker.createInteractiveControl("move_y",
                                                                                        "Move along Y Axis",
                                                                                        InteractiveMode::MOVE_AXIS,
                                                                                        OrientationMode::INHERIT,
@@ -294,7 +294,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
   makeArrow(*control2, 0.5);
   makeArrow(*control2, -0.5);
 
-  InteractiveMarkerControl::Ptr control5 = interactive_marker.createInteractiveControl("rotate_y",
+  InteractiveMarkerControl::SharedPtr control5 = interactive_marker.createInteractiveControl("rotate_y",
                                                                                        "Rotate around Y Axis",
                                                                                        InteractiveMode::ROTATE_AXIS,
                                                                                        OrientationMode::INHERIT,
@@ -302,7 +302,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
                                                                                        Ogre::Quaternion(1, 0, 0, 1));
   makeDisc(*control5, 0.3f);
 
-  InteractiveMarkerControl::Ptr control3 = interactive_marker.createInteractiveControl("move_z",
+  InteractiveMarkerControl::SharedPtr control3 = interactive_marker.createInteractiveControl("move_z",
                                                                                        "Move along Z Axis",
                                                                                        InteractiveMode::MOVE_AXIS,
                                                                                        OrientationMode::INHERIT,
@@ -311,7 +311,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
   makeArrow(*control3, 0.5);
   makeArrow(*control3, -0.5);
 
-  InteractiveMarkerControl::Ptr control6 = interactive_marker.createInteractiveControl("rotate_z",
+  InteractiveMarkerControl::SharedPtr control6 = interactive_marker.createInteractiveControl("rotate_z",
                                                                                        "Rotate around Z Axis",
                                                                                        InteractiveMode::ROTATE_AXIS,
                                                                                        OrientationMode::INHERIT,

--- a/tesseract_rviz/src/markers/utils.cpp
+++ b/tesseract_rviz/src/markers/utils.cpp
@@ -38,13 +38,11 @@
 #include <rviz_common/display_context.hpp>
 #include <rviz_rendering/objects/shape.hpp>
 
-#include <boost/make_shared.hpp>
-
 namespace tesseract_rviz
 {
 void makeSphere(InteractiveMarkerControl& control, float radius)
 {
-  SphereMarker::SharedPtr marker = boost::make_shared<SphereMarker>(
+  SphereMarker::Ptr marker = std::make_shared<SphereMarker>(
       control.getName(), 0, control.getDisplayContext(), control.getMarkerSceneNode(), radius);
   marker->setScale(Ogre::Vector3(control.getSize(), control.getSize(), control.getSize()));
   marker->setColor(Ogre::ColourValue(1.0f, 1.0f, 0.0f, 0.5f));
@@ -74,7 +72,7 @@ void makeArrow(InteractiveMarkerControl& control, float pos)
   point2.y = 0;
   point2.z = 0;
 
-  ArrowMarker::SharedPtr marker = boost::make_shared<ArrowMarker>(
+  ArrowMarker::Ptr marker = std::make_shared<ArrowMarker>(
       control.getName(), 0, point1, point2, control.getDisplayContext(), control.getMarkerSceneNode());
   marker->setColor(default_color);
   marker->setOrientation(control.getControlOrientation());
@@ -86,7 +84,7 @@ void makeArrow(InteractiveMarkerControl& control, float pos)
 void makeTitle(InteractiveMarkerControl& control, const std::string& text)
 {
   Ogre::ColourValue default_color(1, 1, 1, 1);
-  TextViewFacingMarker::SharedPtr marker = boost::make_shared<TextViewFacingMarker>(
+  TextViewFacingMarker::Ptr marker = std::make_shared<TextViewFacingMarker>(
       control.getName(), 0, text, control.getDisplayContext(), control.getMarkerSceneNode());
   marker->setColor(default_color);
   float scale = control.getSize();
@@ -224,7 +222,7 @@ void makeDisc(InteractiveMarkerControl& control, float width)
       break;
   }
 
-  TriangleListMarker::SharedPtr marker = boost::make_shared<TriangleListMarker>(
+  TriangleListMarker::Ptr marker = std::make_shared<TriangleListMarker>(
       control.getName(), 0, control.getDisplayContext(), control.getMarkerSceneNode(), default_color, points, colors);
   marker->setOrientation(control.getControlOrientation());
   float scale = control.getSize();
@@ -260,7 +258,7 @@ void makeDisc(InteractiveMarkerControl& control, float width)
 
 void make6Dof(InteractiveMarker& interactive_marker)
 {
-  InteractiveMarkerControl::SharedPtr control = interactive_marker.createInteractiveControl("move_rotate_3d",
+  InteractiveMarkerControl::Ptr control = interactive_marker.createInteractiveControl("move_rotate_3d",
                                                                                       "Move Rotate 3D",
                                                                                       InteractiveMode::MOVE_ROTATE_3D,
                                                                                       OrientationMode::INHERIT,
@@ -268,7 +266,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
                                                                                       Ogre::Quaternion(1, 0, 0, 0));
   makeSphere(*control, 0.5f);
 
-  InteractiveMarkerControl::SharedPtr control1 = interactive_marker.createInteractiveControl("move_x",
+  InteractiveMarkerControl::Ptr control1 = interactive_marker.createInteractiveControl("move_x",
                                                                                        "Move along X Axis",
                                                                                        InteractiveMode::MOVE_AXIS,
                                                                                        OrientationMode::INHERIT,
@@ -277,7 +275,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
   makeArrow(*control1, 0.5);
   makeArrow(*control1, -0.5);
 
-  InteractiveMarkerControl::SharedPtr control4 = interactive_marker.createInteractiveControl("rotate_x",
+  InteractiveMarkerControl::Ptr control4 = interactive_marker.createInteractiveControl("rotate_x",
                                                                                        "Rotate around X Axis",
                                                                                        InteractiveMode::ROTATE_AXIS,
                                                                                        OrientationMode::INHERIT,
@@ -285,7 +283,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
                                                                                        Ogre::Quaternion(1, 1, 0, 0));
   makeDisc(*control4, 0.3f);
 
-  InteractiveMarkerControl::SharedPtr control2 = interactive_marker.createInteractiveControl("move_y",
+  InteractiveMarkerControl::Ptr control2 = interactive_marker.createInteractiveControl("move_y",
                                                                                        "Move along Y Axis",
                                                                                        InteractiveMode::MOVE_AXIS,
                                                                                        OrientationMode::INHERIT,
@@ -294,7 +292,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
   makeArrow(*control2, 0.5);
   makeArrow(*control2, -0.5);
 
-  InteractiveMarkerControl::SharedPtr control5 = interactive_marker.createInteractiveControl("rotate_y",
+  InteractiveMarkerControl::Ptr control5 = interactive_marker.createInteractiveControl("rotate_y",
                                                                                        "Rotate around Y Axis",
                                                                                        InteractiveMode::ROTATE_AXIS,
                                                                                        OrientationMode::INHERIT,
@@ -302,7 +300,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
                                                                                        Ogre::Quaternion(1, 0, 0, 1));
   makeDisc(*control5, 0.3f);
 
-  InteractiveMarkerControl::SharedPtr control3 = interactive_marker.createInteractiveControl("move_z",
+  InteractiveMarkerControl::Ptr control3 = interactive_marker.createInteractiveControl("move_z",
                                                                                        "Move along Z Axis",
                                                                                        InteractiveMode::MOVE_AXIS,
                                                                                        OrientationMode::INHERIT,
@@ -311,7 +309,7 @@ void make6Dof(InteractiveMarker& interactive_marker)
   makeArrow(*control3, 0.5);
   makeArrow(*control3, -0.5);
 
-  InteractiveMarkerControl::SharedPtr control6 = interactive_marker.createInteractiveControl("rotate_z",
+  InteractiveMarkerControl::Ptr control6 = interactive_marker.createInteractiveControl("rotate_z",
                                                                                        "Rotate around Z Axis",
                                                                                        InteractiveMode::ROTATE_AXIS,
                                                                                        OrientationMode::INHERIT,

--- a/tesseract_rviz/src/property/button_property.cpp
+++ b/tesseract_rviz/src/property/button_property.cpp
@@ -7,7 +7,7 @@ namespace tesseract_rviz
 ButtonProperty::ButtonProperty(const QString& name,
                                const QString& default_value,
                                const QString& description,
-                               rviz::Property* parent,
+                               rviz_common::properties::Property* parent,
                                const char* changed_slot,
                                QObject* receiver)
   : Property(name, default_value, description, parent, changed_slot, receiver), button_(nullptr), captions_("")

--- a/tesseract_rviz/src/render_tools/joint_state_monitor_widget.cpp
+++ b/tesseract_rviz/src/render_tools/joint_state_monitor_widget.cpp
@@ -1,8 +1,8 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <rviz/display_context.h>
-#include <rviz/properties/ros_topic_property.h>
-#include <rviz/window_manager_interface.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/properties/ros_topic_property.hpp>
+#include <rviz_common/window_manager_interface.hpp>
 
 #include <tesseract_rosutils/utils.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
@@ -11,15 +11,15 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_rviz
 {
-JointStateMonitorWidget::JointStateMonitorWidget(rviz::Property* widget, rviz::Display* display)
-  : widget_(widget), display_(display), visualization_(nullptr), env_(nullptr), update_required_(false)
+JointStateMonitorWidget::JointStateMonitorWidget(rviz_common::properties::Property* widget, rviz_common::Display* display)
+  : widget_(widget), display_(display), visualization_(nullptr), tesseract_(nullptr), update_required_(false)
 {
-  main_property_ = new rviz::Property(
+  main_property_ = new rviz_common::properties::Property(
       "Joint State Monitor", "", "Monitor a joint state topic and update the visualization", widget_, nullptr, this);
 
-  joint_state_topic_property_ = new rviz::RosTopicProperty("Topic",
+  joint_state_topic_property_ = new rviz_common::properties::RosTopicProperty("Topic",
                                                            "joint_states",
-                                                           ros::message_traits::datatype<sensor_msgs::JointState>(),
+                                                           "sensor_msgs::JointState",
                                                            "The topic on which the sensor_msgs::JointState messages "
                                                            "are received",
                                                            main_property_,
@@ -27,56 +27,66 @@ JointStateMonitorWidget::JointStateMonitorWidget(rviz::Property* widget, rviz::D
                                                            this);
 }
 
-JointStateMonitorWidget::~JointStateMonitorWidget() { joint_state_subscriber_.shutdown(); }
+JointStateMonitorWidget::~JointStateMonitorWidget() { /*joint_state_subscriber_.shutdown();*/ }
 
-void JointStateMonitorWidget::onInitialize(VisualizationWidget::Ptr visualization,
-                                           tesseract_environment::Environment::Ptr env,
-                                           rviz::DisplayContext* /*context*/,
-                                           const ros::NodeHandle& update_nh)
+void JointStateMonitorWidget::onInitialize(VisualizationWidget::SharedPtr visualization,
+                                           tesseract::Tesseract::Ptr tesseract,
+                                           rviz_common::DisplayContext* context,
+                                           rclcpp::Node::SharedPtr update_node)
 {
   visualization_ = std::move(visualization);
-  env_ = std::move(env);
-  nh_ = update_nh;
+  tesseract_ = std::move(tesseract);
+  node_ = update_node;
+
+  auto rviz_ros_node = context->getRosNodeAbstraction();
+  joint_state_topic_property_->initialize(rviz_ros_node);
 }
 
 void JointStateMonitorWidget::changedJointStateTopic()
 {
-  joint_state_subscriber_.shutdown();
+  if(joint_state_topic_property_ && joint_state_topic_property_->getStdString() != "")
+  {
+  joint_state_subscriber_.reset();
 
-  joint_state_subscriber_ = nh_.subscribe(
-      joint_state_topic_property_->getStdString(), 10, &JointStateMonitorWidget::newJointStateCallback, this);
+  auto current_state_cb = std::bind(&JointStateMonitorWidget::newJointStateCallback, this, std::placeholders::_1);
+  joint_state_subscriber_ = node_->create_subscription<sensor_msgs::msg::JointState>(
+      joint_state_topic_property_->getStdString(), 10, current_state_cb);
+  }
+  else
+    CONSOLE_BRIDGE_logWarn("joint state topic is invalid");
 }
 
-void JointStateMonitorWidget::newJointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state_msg)
+void JointStateMonitorWidget::newJointStateCallback(const sensor_msgs::msg::JointState::ConstSharedPtr joint_state_msg)
 {
-  if (!env_->isInitialized())
+  if (!tesseract_->isInitialized())
     return;
 
   if (isUpdateRequired(*joint_state_msg))
   {
-    tesseract_rosutils::processMsg(env_, *joint_state_msg);
+    CONSOLE_BRIDGE_logWarn("Conversion has not been defined in rosutils yet. Go do that.");
+    tesseract_rosutils::processMsg(tesseract_->getEnvironment(), *joint_state_msg);
     update_required_ = true;
   }
 }
 
 void JointStateMonitorWidget::onEnable() { changedJointStateTopic(); }
 
-void JointStateMonitorWidget::onDisable() { joint_state_subscriber_.shutdown(); }
+void JointStateMonitorWidget::onDisable() { joint_state_subscriber_.reset(); }
 
 void JointStateMonitorWidget::onUpdate()
 {
-  if (visualization_ && update_required_ && env_)
+  if (visualization_ && update_required_ && tesseract_->getEnvironment())
   {
     update_required_ = false;
-    visualization_->update(env_->getState().link_transforms);
+    visualization_->update(tesseract_->getEnvironment()->getCurrentState()->link_transforms);
   }
 }
 
 void JointStateMonitorWidget::onReset() { changedJointStateTopic(); }
 
-bool JointStateMonitorWidget::isUpdateRequired(const sensor_msgs::JointState& joint_state)
+bool JointStateMonitorWidget::isUpdateRequired(const sensor_msgs::msg::JointState& joint_state)
 {
-  std::unordered_map<std::string, double> joints = env_->getState().joints;
+  std::unordered_map<std::string, double> joints = tesseract_->getEnvironment()->getCurrentState()->joints;
   for (auto i = 0u; i < joint_state.name.size(); ++i)
     if (std::abs(joints[joint_state.name[i]] - joint_state.position[i]) > 1e-5)
       return true;

--- a/tesseract_rviz/src/render_tools/joint_state_monitor_widget.cpp
+++ b/tesseract_rviz/src/render_tools/joint_state_monitor_widget.cpp
@@ -44,21 +44,25 @@ void JointStateMonitorWidget::onInitialize(VisualizationWidget::Ptr visualizatio
 
 void JointStateMonitorWidget::changedJointStateTopic()
 {
-  if(joint_state_topic_property_ && joint_state_topic_property_->getStdString() != "")
+  if (joint_state_topic_property_ && joint_state_topic_property_->getStdString() != "")
   {
-  joint_state_subscriber_.reset();
-
-  auto current_state_cb = std::bind(&JointStateMonitorWidget::newJointStateCallback, this, std::placeholders::_1);
-  joint_state_subscriber_ = node_->create_subscription<sensor_msgs::msg::JointState>(
-      joint_state_topic_property_->getStdString(), 10, current_state_cb);
+    joint_state_subscriber_.reset();
+    joint_state_subscriber_ = node_->create_subscription<sensor_msgs::msg::JointState>(
+        joint_state_topic_property_->getStdString(), 10,
+        [this](sensor_msgs::msg::JointState::ConstSharedPtr msg)
+        {
+          newJointStateCallback(msg);
+        }
+    );
   }
   else
+  {
     CONSOLE_BRIDGE_logWarn("joint state topic is invalid");
+  }
 }
 
 void JointStateMonitorWidget::newJointStateCallback(const sensor_msgs::msg::JointState::ConstSharedPtr joint_state_msg)
 {
-  RCLCPP_INFO(node_->get_logger().get_child("joint_state_monitor"), "Got joints!");
   if (!env_->isInitialized())
     return;
 

--- a/tesseract_rviz/src/render_tools/joint_widget.cpp
+++ b/tesseract_rviz/src/render_tools/joint_widget.cpp
@@ -35,13 +35,13 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <OgreSceneNode.h>
 
-#include "rviz/load_resource.h"
-#include "rviz/ogre_helpers/arrow.h"
-#include "rviz/ogre_helpers/axes.h"
-#include "rviz/properties/float_property.h"
-#include "rviz/properties/quaternion_property.h"
-#include "rviz/properties/string_property.h"
-#include "rviz/properties/vector_property.h"
+#include "rviz_common/load_resource.hpp"
+#include "rviz_rendering/objects/arrow.hpp"
+#include "rviz_rendering/objects/axes.hpp"
+#include "rviz_common/properties/float_property.hpp"
+#include "rviz_common/properties/quaternion_property.hpp"
+#include "rviz_common/properties/string_property.hpp"
+#include "rviz_common/properties/vector_property.hpp"
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/conversions.h>
@@ -58,28 +58,28 @@ JointWidget::JointWidget(VisualizationWidget* env, const tesseract_scene_graph::
   , axes_(nullptr)
   , axis_(nullptr)
 {
-  joint_property_ = new rviz::Property(name_.c_str(), true, "", nullptr, SLOT(updateChildVisibility()), this);
-  joint_property_->setIcon(rviz::loadPixmap("package://rviz/icons/classes/RobotJoint.png"));
+  joint_property_ = new rviz_common::properties::Property(name_.c_str(), true, "", nullptr, SLOT(updateChildVisibility()), this);
+  joint_property_->setIcon(rviz_common::loadPixmap("package://rviz/icons/classes/RobotJoint.png"));
 
-  details_ = new rviz::Property("Details", QVariant(), "", nullptr);
+  details_ = new rviz_common::properties::Property("Details", QVariant(), "", nullptr);
 
-  axes_property_ = new rviz::Property(
+  axes_property_ = new rviz_common::properties::Property(
       "Show Axes", false, "Enable/disable showing the axes of this joint.", joint_property_, SLOT(updateAxes()), this);
 
-  position_property_ = new rviz::VectorProperty("Position",
+  position_property_ = new rviz_common::properties::VectorProperty("Position",
                                                 Ogre::Vector3::ZERO,
                                                 "Position of this joint, in the current Fixed Frame.  (Not editable)",
                                                 joint_property_);
   position_property_->setReadOnly(true);
 
-  orientation_property_ = new rviz::QuaternionProperty("Orientation",
+  orientation_property_ = new rviz_common::properties::QuaternionProperty("Orientation",
                                                        Ogre::Quaternion::IDENTITY,
                                                        "Orientation of this joint, in the current Fixed Frame.  (Not "
                                                        "editable)",
                                                        joint_property_);
   orientation_property_->setReadOnly(true);
 
-  std::string type;
+  std::string type = "";
   if (joint.type == tesseract_scene_graph::JointType::UNKNOWN)
     type = "unknown";
   else if (joint.type == tesseract_scene_graph::JointType::REVOLUTE)
@@ -95,7 +95,7 @@ JointWidget::JointWidget(VisualizationWidget* env, const tesseract_scene_graph::
   else if (joint.type == tesseract_scene_graph::JointType::FIXED)
     type = "fixed";
 
-  type_property_ = new rviz::StringProperty(
+  type_property_ = new rviz_common::properties::StringProperty(
       "Type", QString::fromStdString(type), "Type of this joint.  (Not editable)", joint_property_);
   type_property_->setReadOnly(true);
 
@@ -103,13 +103,13 @@ JointWidget::JointWidget(VisualizationWidget* env, const tesseract_scene_graph::
   {
     // continuous joints have lower limit and upper limits of zero,
     // which means this isn't very useful but show it anyhow.
-    lower_limit_property_ = new rviz::FloatProperty("Lower Limit",
+    lower_limit_property_ = new rviz_common::properties::FloatProperty("Lower Limit",
                                                     static_cast<float>(joint.limits->lower),
                                                     "Lower limit of this joint.  (Not editable)",
                                                     joint_property_);
     lower_limit_property_->setReadOnly(true);
 
-    upper_limit_property_ = new rviz::FloatProperty("Upper Limit",
+    upper_limit_property_ = new rviz_common::properties::FloatProperty("Upper Limit",
                                                     static_cast<float>(joint.limits->upper),
                                                     "Upper limit of this joint.  (Not editable)",
                                                     joint_property_);
@@ -118,14 +118,14 @@ JointWidget::JointWidget(VisualizationWidget* env, const tesseract_scene_graph::
 
   if ((type == "continuous") || (type == "revolute") || (type == "prismatic") || (type == "planar"))
   {
-    show_axis_property_ = new rviz::Property("Show Joint Axis",
+    show_axis_property_ = new rviz_common::properties::Property("Show Joint Axis",
                                              false,
                                              "Enable/disable showing the axis of this joint.",
                                              joint_property_,
                                              SLOT(updateAxis()),
                                              this);
 
-    axis_property_ = new rviz::VectorProperty("Joint Axis",
+    axis_property_ = new rviz_common::properties::VectorProperty("Joint Axis",
                                               Ogre::Vector3(static_cast<float>(joint.axis(0)),
                                                             static_cast<float>(joint.axis(1)),
                                                             static_cast<float>(joint.axis(2))),
@@ -147,9 +147,9 @@ JointWidget::JointWidget(VisualizationWidget* env, const tesseract_scene_graph::
 
 JointWidget::~JointWidget()
 {
-  assert(details_->getParent() == nullptr);
-  assert(joint_property_->getParent() == nullptr);
-
+  delete axes_;
+  if (axis_)
+    delete axis_;
   delete details_;
   delete joint_property_;
 }
@@ -197,7 +197,7 @@ void JointWidget::setJointPropertyDescription()
   joint_property_->setDescription(desc.str().c_str());
 }
 
-void JointWidget::setJointCheckbox(const QVariant& val)
+void JointWidget::setJointCheckbox(QVariant val)
 {
   // setting doing_set_checkbox_ to true prevents updateChildVisibility() from
   // updating child link enables.
@@ -347,7 +347,7 @@ void JointWidget::updateAxes()
   {
     if (!axes_)
     {
-      axes_ = std::make_unique<rviz::Axes>(env_->getSceneManager(), env_->getOtherNode(), 0.1f, 0.01f);
+      axes_ = new rviz_rendering::Axes(env_->getSceneManager(), env_->getOtherNode(), 0.1f, 0.01f);
       axes_->getSceneNode()->setVisible(getEnabled());
 
       axes_->setPosition(position_property_->getVector());
@@ -357,7 +357,10 @@ void JointWidget::updateAxes()
   else
   {
     if (axes_)
+    {
+      delete axes_;
       axes_ = nullptr;
+    }
   }
 }
 
@@ -367,7 +370,7 @@ void JointWidget::updateAxis()
   {
     if (!axis_)
     {
-      axis_ = std::make_unique<rviz::Arrow>(env_->getSceneManager(), env_->getOtherNode(), 0.15f, 0.05f, 0.05f, 0.08f);
+      axis_ = new rviz_rendering::Arrow(env_->getSceneManager(), env_->getOtherNode(), 0.15f, 0.05f, 0.05f, 0.08f);
       axis_->getSceneNode()->setVisible(getEnabled());
 
       axis_->setPosition(position_property_->getVector());
@@ -381,7 +384,10 @@ void JointWidget::updateAxis()
   else
   {
     if (axis_)
+    {
+      delete axis_;
       axis_ = nullptr;
+    }
   }
 }
 
@@ -409,39 +415,23 @@ void JointWidget::setTransforms(const Ogre::Vector3& parent_link_position,
 
 void JointWidget::hideSubProperties(bool hide)
 {
-  details_->setHidden(hide);
   position_property_->setHidden(hide);
   orientation_property_->setHidden(hide);
-  type_property_->setHidden(hide);
-
-  if (axes_property_)
-    axes_property_->setHidden(hide);
-
-  if (show_axis_property_)
-    show_axis_property_->setHidden(hide);
-
-  if (axis_property_)
-    axis_property_->setHidden(hide);
-
-  if (lower_limit_property_)
-    lower_limit_property_->setHidden(hide);
-
-  if (upper_limit_property_)
-    upper_limit_property_->setHidden(hide);
+  axes_property_->setHidden(hide);
+  show_axis_property_->setHidden(hide);
+  axis_property_->setHidden(hide);
 }
 
 Ogre::Vector3 JointWidget::getPosition() { return position_property_->getVector(); }
 Ogre::Quaternion JointWidget::getOrientation() { return orientation_property_->getQuaternion(); }
-void JointWidget::setParentProperty(rviz::Property* new_parent)
+void JointWidget::setParentProperty(rviz_common::properties::Property* new_parent)
 {
-  rviz::Property* old_parent = joint_property_->getParent();
+  rviz_common::properties::Property* old_parent = joint_property_->getParent();
   if (old_parent)
     old_parent->takeChild(joint_property_);
 
   if (new_parent)
     new_parent->addChild(joint_property_);
-
-  joint_property_->setParent(new_parent);
 }
 
 // if use_detail:
@@ -452,7 +442,7 @@ void JointWidget::setParentProperty(rviz::Property* new_parent)
 //    details_ property does not have a parent.
 void JointWidget::useDetailProperty(bool use_detail)
 {
-  rviz::Property* old_parent = details_->getParent();
+  rviz_common::properties::Property* old_parent = details_->getParent();
   if (old_parent)
     old_parent->takeChild(details_);
 
@@ -460,7 +450,7 @@ void JointWidget::useDetailProperty(bool use_detail)
   {
     while (joint_property_->numChildren() > 0)
     {
-      rviz::Property* child = joint_property_->childAt(0);
+      rviz_common::properties::Property* child = joint_property_->childAt(0);
       joint_property_->takeChild(child);
       details_->addChild(child);
     }
@@ -471,7 +461,7 @@ void JointWidget::useDetailProperty(bool use_detail)
   {
     while (details_->numChildren() > 0)
     {
-      rviz::Property* child = details_->childAt(0);
+      rviz_common::properties::Property* child = details_->childAt(0);
       details_->takeChild(child);
       joint_property_->addChild(child);
     }
@@ -480,7 +470,7 @@ void JointWidget::useDetailProperty(bool use_detail)
 
 void JointWidget::expandDetails(bool expand)
 {
-  rviz::Property* parent = details_->getParent() ? details_ : joint_property_;
+  rviz_common::properties::Property* parent = details_->getParent() ? details_ : joint_property_;
   if (expand)
   {
     parent->expand();

--- a/tesseract_rviz/src/render_tools/joint_widget.cpp
+++ b/tesseract_rviz/src/render_tools/joint_widget.cpp
@@ -79,7 +79,7 @@ JointWidget::JointWidget(VisualizationWidget* env, const tesseract_scene_graph::
                                                        joint_property_);
   orientation_property_->setReadOnly(true);
 
-  std::string type = "";
+  std::string type;
   if (joint.type == tesseract_scene_graph::JointType::UNKNOWN)
     type = "unknown";
   else if (joint.type == tesseract_scene_graph::JointType::REVOLUTE)
@@ -147,9 +147,9 @@ JointWidget::JointWidget(VisualizationWidget* env, const tesseract_scene_graph::
 
 JointWidget::~JointWidget()
 {
-  delete axes_;
-  if (axis_)
-    delete axis_;
+  assert(details_->getParent() == nullptr);
+  assert(joint_property_->getParent() == nullptr);
+
   delete details_;
   delete joint_property_;
 }
@@ -197,7 +197,7 @@ void JointWidget::setJointPropertyDescription()
   joint_property_->setDescription(desc.str().c_str());
 }
 
-void JointWidget::setJointCheckbox(QVariant val)
+void JointWidget::setJointCheckbox(const QVariant& val)
 {
   // setting doing_set_checkbox_ to true prevents updateChildVisibility() from
   // updating child link enables.
@@ -347,7 +347,7 @@ void JointWidget::updateAxes()
   {
     if (!axes_)
     {
-      axes_ = new rviz_rendering::Axes(env_->getSceneManager(), env_->getOtherNode(), 0.1f, 0.01f);
+      axes_ = std::make_unique<rviz_rendering::Axes>(env_->getSceneManager(), env_->getOtherNode(), 0.1f, 0.01f);
       axes_->getSceneNode()->setVisible(getEnabled());
 
       axes_->setPosition(position_property_->getVector());
@@ -357,10 +357,7 @@ void JointWidget::updateAxes()
   else
   {
     if (axes_)
-    {
-      delete axes_;
       axes_ = nullptr;
-    }
   }
 }
 
@@ -370,7 +367,7 @@ void JointWidget::updateAxis()
   {
     if (!axis_)
     {
-      axis_ = new rviz_rendering::Arrow(env_->getSceneManager(), env_->getOtherNode(), 0.15f, 0.05f, 0.05f, 0.08f);
+      axis_ = std::make_unique<rviz_rendering::Arrow>(env_->getSceneManager(), env_->getOtherNode(), 0.15f, 0.05f, 0.05f, 0.08f);
       axis_->getSceneNode()->setVisible(getEnabled());
 
       axis_->setPosition(position_property_->getVector());
@@ -384,10 +381,7 @@ void JointWidget::updateAxis()
   else
   {
     if (axis_)
-    {
-      delete axis_;
       axis_ = nullptr;
-    }
   }
 }
 
@@ -415,11 +409,25 @@ void JointWidget::setTransforms(const Ogre::Vector3& parent_link_position,
 
 void JointWidget::hideSubProperties(bool hide)
 {
+  details_->setHidden(hide);
   position_property_->setHidden(hide);
   orientation_property_->setHidden(hide);
-  axes_property_->setHidden(hide);
-  show_axis_property_->setHidden(hide);
-  axis_property_->setHidden(hide);
+  type_property_->setHidden(hide);
+
+  if (axes_property_)
+    axes_property_->setHidden(hide);
+
+  if (show_axis_property_)
+    show_axis_property_->setHidden(hide);
+
+  if (axis_property_)
+    axis_property_->setHidden(hide);
+
+  if (lower_limit_property_)
+    lower_limit_property_->setHidden(hide);
+
+  if (upper_limit_property_)
+    upper_limit_property_->setHidden(hide);
 }
 
 Ogre::Vector3 JointWidget::getPosition() { return position_property_->getVector(); }
@@ -432,6 +440,8 @@ void JointWidget::setParentProperty(rviz_common::properties::Property* new_paren
 
   if (new_parent)
     new_parent->addChild(joint_property_);
+
+  joint_property_->setParent(new_parent);
 }
 
 // if use_detail:

--- a/tesseract_rviz/src/render_tools/link_widget.cpp
+++ b/tesseract_rviz/src/render_tools/link_widget.cpp
@@ -82,12 +82,6 @@ static Ogre::NameGenerator material_name_generator("Tesseract_Material");
 static Ogre::NameGenerator trail_name_generator("Tesseract_Trail");
 static Ogre::NameGenerator point_cloud_name_generator("Tesseract_PointCloud");
 
-#ifdef noetic_BUILD
-const std::string GROUP_NAME = Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME;
-#else
-const std::string GROUP_NAME = "rviz";
-#endif
-
 class EnvLinkSelectionHandler : public rviz_common::interaction::SelectionHandler
 {
 public:
@@ -677,7 +671,8 @@ Ogre::MaterialPtr LinkWidget::getMaterialForLink(const tesseract_scene_graph::Li
     return Ogre::MaterialManager::getSingleton().getByName("RVIZ/ShadedRed");
   }
 
-  Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(material_name_generator.generate(), GROUP_NAME);
+  Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(material_name_generator.generate(),
+      Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
   mat->getTechnique(0)->setLightingEnabled(true);
 
   tesseract_scene_graph::Visual::Ptr visual = nullptr;

--- a/tesseract_rviz/src/render_tools/manipulation_widget.cpp
+++ b/tesseract_rviz/src/render_tools/manipulation_widget.cpp
@@ -29,18 +29,17 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/algorithm/string/replace.hpp>
 #include <functional>
 
-#include <rviz/display_context.h>
-#include <rviz/properties/property.h>
-#include <rviz/properties/enum_property.h>
-#include <rviz/properties/ros_topic_property.h>
-#include <rviz/properties/float_property.h>
-#include <rviz/properties/bool_property.h>
-#include <rviz/properties/string_property.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/properties/property.hpp>
+#include <rviz_common/properties/enum_property.hpp>
+#include <rviz_common/properties/ros_topic_property.hpp>
+#include <rviz_common/properties/float_property.hpp>
+#include <rviz_common/properties/bool_property.hpp>
+#include <rviz_common/properties/string_property.hpp>
 
-#include <rviz/window_manager_interface.h>
+#include <rviz_common/window_manager_interface.hpp>
 
 #include <tesseract_rosutils/utils.h>
-#include <tesseract_motion_planners/robot_config.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/markers/utils.h>
@@ -53,16 +52,17 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_rviz
 {
-ManipulationWidget::ManipulationWidget(rviz::Property* widget, rviz::Display* display)
-  : root_interactive_node_(nullptr)
-  , widget_(widget)
+ManipulationWidget::ManipulationWidget(rviz_common::properties::Property* widget, rviz_common::Display* display)
+  : widget_(widget)
+  , root_interactive_node_(nullptr)
   , display_(display)
   , visualization_(nullptr)
-  , env_(nullptr)
+  , tesseract_(nullptr)
   , state_(ManipulatorState::START)
   , env_revision_(0)
-  , tcp_offset_(Eigen::Isometry3d::Identity())
+  , env_state_(nullptr)
   , enabled_(false)
+  , tcp_(Eigen::Isometry3d::Identity())
 //  , trajectory_slider_panel_(nullptr)
 //  , trajectory_slider_dock_panel_(nullptr)
 {
@@ -75,7 +75,7 @@ ManipulationWidget::ManipulationWidget(rviz::Property* widget, rviz::Display* di
 
   main_property_->setCaptions("Reset");
 
-  joint_state_topic_property_ = new rviz::RosTopicProperty("Topic",
+  joint_state_topic_property_ = new rviz_common::properties::RosTopicProperty("Topic",
                                                            "/tesseract/manipulation_joint_states",
                                                            ros::message_traits::datatype<sensor_msgs::JointState>(),
                                                            "The topic on which the sensor_msgs::JointState messages "
@@ -84,22 +84,20 @@ ManipulationWidget::ManipulationWidget(rviz::Property* widget, rviz::Display* di
                                                            SLOT(changedJointStateTopic()),
                                                            this);
 
-  manipulator_property_ = new rviz::EnumProperty(
+  manipulator_property_ = new rviz_common::properties::EnumProperty(
       "Manipulator", "", "The manipulator to move around.", main_property_, SLOT(changedManipulator()), this);
 
-  tcp_frame_property_ = new rviz::EnumProperty(
-      "TCP Frame", "", "The tool center point frame", main_property_, SLOT(changedTCPFrame()), this);
-  tcp_offset_property_ = new rviz::EnumProperty(
-      "TCP Offset", "", "The tool center point offset", main_property_, SLOT(changedTCPOffset()), this);
+  tcp_property_ =
+      new rviz_common::properties::EnumProperty("TCP Link", "", "The tool center point link", main_property_, SLOT(changedTCP()), this);
 
-  cartesian_manipulation_property_ = new rviz::BoolProperty("Cartesian Manipulation",
+  cartesian_manipulation_property_ = new rviz_common::properties::BoolProperty("Cartesian Manipulation",
                                                             true,
                                                             "Tool for cartesian manipulation of kinematics objects",
                                                             main_property_,
                                                             SLOT(changedCartesianManipulationEnabled()),
                                                             this);
 
-  cartesian_marker_scale_property_ = new rviz::FloatProperty("Marker Scale",
+  cartesian_marker_scale_property_ = new rviz_common::properties::FloatProperty("Marker Scale",
                                                              0.5,
                                                              "Change the scale of the cartesian interactive marker",
                                                              cartesian_manipulation_property_,
@@ -107,14 +105,14 @@ ManipulationWidget::ManipulationWidget(rviz::Property* widget, rviz::Display* di
                                                              this);
   cartesian_marker_scale_property_->setMin(0.001f);
 
-  joint_manipulation_property_ = new rviz::BoolProperty("Joint Manipulation",
+  joint_manipulation_property_ = new rviz_common::properties::BoolProperty("Joint Manipulation",
                                                         true,
                                                         "Tool for joint manipulation of kinematics objects",
                                                         main_property_,
                                                         SLOT(changedJointManipulationEnabled()),
                                                         this);
 
-  joint_marker_scale_property_ = new rviz::FloatProperty("Marker Scale",
+  joint_marker_scale_property_ = new rviz_common::properties::FloatProperty("Marker Scale",
                                                          0.5,
                                                          "Change the scale of the joint interactive markers",
                                                          joint_manipulation_property_,
@@ -123,27 +121,9 @@ ManipulationWidget::ManipulationWidget(rviz::Property* widget, rviz::Display* di
   joint_marker_scale_property_->setMin(0.001f);
 
   joint_values_property_ =
-      new rviz::Property("Joint Values", "", "Shows current joint values", main_property_, nullptr, this);
+      new rviz_common::properties::Property("Joint Values", "", "Shows current joint values", main_property_, nullptr, this);
 
-  joint_config_property_ = new rviz::StringProperty(
-      "Joint Config", "Unknown", "Shows current joint configuration", main_property_, nullptr, this);
-  joint_config_property_->setReadOnly(true);
-  joint_config_base_link_property_ = new rviz::EnumProperty(
-      "Robot Base Link", "", "This is the base link of the industrial robot.", joint_config_property_, nullptr, this);
-  joint_config_tip_link_property_ = new rviz::EnumProperty(
-      "Robot Tip Link", "", "This is the tip link of the industrial robot", joint_config_property_, nullptr, this);
-
-  joint3_sign_property_ =
-      new rviz::EnumProperty("Joint 3 Sign Correction", "+1", "", joint_config_property_, nullptr, this);
-  joint3_sign_property_->addOptionStd("+1", 1);
-  joint3_sign_property_->addOptionStd("-1", -1);
-  joint3_sign_property_->setShouldBeSaved(true);
-
-  joint5_sign_property_ =
-      new rviz::EnumProperty("Joint 5 Sign Correction", "+1", "", joint_config_property_, nullptr, this);
-  joint5_sign_property_->addOptionStd("+1", 1);
-  joint5_sign_property_->addOptionStd("-1", -1);
-  joint5_sign_property_->setShouldBeSaved(true);
+  joint_values_property_->setReadOnly(true);
 }
 
 ManipulationWidget::~ManipulationWidget()
@@ -156,35 +136,36 @@ ManipulationWidget::~ManipulationWidget()
 }
 
 void ManipulationWidget::onInitialize(Ogre::SceneNode* root_node,
-                                      rviz::DisplayContext* context,
-                                      VisualizationWidget::Ptr visualization,
-                                      tesseract_environment::Environment::Ptr env,
-                                      const ros::NodeHandle& update_nh,
+                                      rviz_common::DisplayContext* context,
+                                      VisualizationWidget::SharedPtr visualization,
+                                      tesseract::Tesseract::Ptr tesseract,
+                                      ros::NodeHandle update_nh,
                                       ManipulatorState state,
-                                      const QString& joint_state_topic)
+                                      QString joint_state_topic)
 {
   // Save pointers for later use
   visualization_ = std::move(visualization);
-  env_ = std::move(env);
+  tesseract_ = std::move(tesseract);
   context_ = context;
   nh_ = update_nh;
   state_ = state;
 
   root_interactive_node_ = root_node->createChildSceneNode();
-  if (env_->isInitialized())
+  if (tesseract_->isInitialized())
   {
     int cnt = 0;
     available_manipulators_.clear();
-    for (const auto& manip : env_->getGroupNames())
+    for (const auto& manip : tesseract_->getInvKinematicsManagerConst()->getAvailableInvKinematicsManipulators())
     {
       available_manipulators_.push_back(QString::fromStdString(manip));
       manipulator_property_->addOptionStd(manip, cnt);
       ++cnt;
     }
 
-    env_revision_ = env_->getRevision();
-    env_state_ = env_->getState();
-    joints_ = env_state_.joints;
+    env_revision_ = tesseract_->getEnvironmentConst()->getRevision();
+    env_state_ =
+        std::make_shared<tesseract_environment::EnvState>(*(tesseract_->getEnvironmentConst()->getCurrentState()));
+    joints_ = env_state_->joints;
   }
 
   joint_state_topic_property_->setValue(joint_state_topic);
@@ -229,7 +210,7 @@ void ManipulationWidget::onEnable()
   for (auto& joint_marker : joint_interactive_markers_)
     joint_marker.second->setVisible(enabled_ && joint_manipulation_property_->getBool());
 
-  env_state_ = tesseract_scene_graph::SceneState();
+  env_state_ = nullptr;
 }
 
 void ManipulationWidget::onDisable()
@@ -255,12 +236,10 @@ void ManipulationWidget::onReset()
   // Clear manipulators
   manipulator_property_->clearOptions();
   available_manipulators_.clear();
-  available_working_frames_.clear();
-  available_tcp_frames_.clear();
-  available_tcp_offsets_.clear();
+  available_tcp_links_.clear();
 }
 
-void ManipulationWidget::onNameChange(const QString& /*name*/)
+void ManipulationWidget::onNameChange(const QString& name)
 {
   //  if (trajectory_slider_dock_panel_)
   //    trajectory_slider_dock_panel_->setWindowTitle(name + " - Slider");
@@ -280,135 +259,80 @@ void ManipulationWidget::enableJointManipulation(bool enabled)
   joint_manipulation_property_->setBool(enabled);
 }
 
-void ManipulationWidget::resetToCurrentState() { env_state_ = tesseract_scene_graph::SceneState(); }
+void ManipulationWidget::resetToCurrentState() { env_state_ = nullptr; }
 
-bool ManipulationWidget::changeManipulator(const QString& manipulator)
+bool ManipulationWidget::changeManipulator(QString manipulator)
 {
-  if (env_->isInitialized())
+  if (tesseract_->isInitialized())
   {
-    manip_ = env_->getKinematicGroup(manipulator.toStdString());
-    if (manip_ == nullptr)
+    inv_kin_ = tesseract_->getInvKinematicsManagerConst()->getInvKinematicSolver(manipulator.toStdString());
+    if (inv_kin_ == nullptr)
       return false;
 
     manipulator_property_->setString(manipulator);
 
-    const auto& scene_graph = env_->getSceneGraph();
-    std::vector<std::string> joint_names = manip_->getJointNames();
-    const Eigen::MatrixX2d& limits = manip_->getLimits().joint_limits;
-    inv_seed_.resize(manip_->numJoints());
+    const auto& scene_graph = tesseract_->getEnvironmentConst()->getSceneGraph();
+    std::vector<std::string> joint_names = inv_kin_->getJointNames();
+    inv_seed_.resize(inv_kin_->numJoints());
     int i = 0;
     joint_values_property_->removeChildren();
     for (auto& j : joint_names)
     {
-      inv_seed_[i] = joints_[j];
-      QString joint_description =
-          QString("Limits: [%1, %2]").arg(QString("%1").arg(limits(i, 0)), QString("%1").arg(limits(i, 1)));
+      inv_seed_[i++] = joints_[j];
+      const auto& joint = scene_graph->getJoint(j);
+      QString joint_description = "Limits: [inf, inf]";
+      if (joint->limits)
+        joint_description = QString("Limits: [%1, %2]")
+                                .arg(QString("%1").arg(joint->limits->lower), QString("%1").arg(joint->limits->upper));
 
-      rviz::FloatProperty* joint_value_property = new rviz::FloatProperty(QString::fromStdString(j),
-                                                                          static_cast<float>(joints_[j]),
-                                                                          joint_description,
-                                                                          nullptr,
-                                                                          SLOT(userInputJointValuesChanged()),
-                                                                          this);
-
-      joint_value_property->setMin(static_cast<float>(limits(i, 0)));
-      joint_value_property->setMax(static_cast<float>(limits(i, 1)));
+      rviz_common::properties::FloatProperty* joint_value_property = new rviz_common::properties::FloatProperty(
+          QString::fromStdString(j), static_cast<float>(joints_[j]), joint_description, nullptr, nullptr, this);
+      joint_value_property->setReadOnly(true);
       joint_values_property_->addChild(joint_value_property);
-      ++i;
     }
 
     // Need to update state information (transforms) because manipulator changes and
-    env_state_ = env_->getState(joints_);
-    updateJointConfig();
+    env_state_ = tesseract_->getEnvironmentConst()->getState(joints_);
 
     // Get available TCP's
-    QString current_tcp_frame = tcp_frame_property_->getString();
-    QString current_tcp_offset = tcp_offset_property_->getString();
+    QString current_tcp = tcp_property_->getString();
+    std::vector<std::string> tcp_links =
+        tesseract_->getEnvironmentConst()->getSceneGraph()->getLinkChildrenNames(inv_kin_->getTipLinkName());
+    tcp_links.push_back(inv_kin_->getTipLinkName());
 
-    QString current_robot_config_base_link = joint_config_base_link_property_->getString();
-    QString current_robot_config_tip_link = joint_config_tip_link_property_->getString();
-
-    std::vector<std::string> tcp_frames = manip_->getAllPossibleTipLinkNames();
-    available_tcp_frames_.clear();
-    tcp_frame_property_->clearOptions();
-    for (const auto& tcp_frame : tcp_frames)
+    available_tcp_links_.clear();
+    tcp_property_->clearOptions();
+    for (const auto& tcp_link : tcp_links)
     {
-      available_tcp_frames_.push_back(QString::fromStdString(tcp_frame));
-      tcp_frame_property_->addOptionStd(tcp_frame);
-      joint_config_tip_link_property_->addOptionStd(tcp_frame);
+      available_tcp_links_.push_back(QString::fromStdString(tcp_link));
+      tcp_property_->addOptionStd(tcp_link);
     }
 
-    std::vector<std::string> working_frames = manip_->getAllValidWorkingFrames();
-    available_working_frames_.clear();
-    joint_config_base_link_property_->clearOptions();
-    for (const auto& working_frame : working_frames)
+    if (current_tcp.isEmpty() || !available_tcp_links_.contains(current_tcp))
     {
-      available_working_frames_.push_back(QString::fromStdString(working_frame));
-      joint_config_base_link_property_->addOptionStd(working_frame);
-    }
-
-    available_tcp_offsets_.clear();
-    tcp_offset_property_->clearOptions();
-    auto group_tcp_offsets = env_->getKinematicsInformation().group_tcps;
-    auto it = group_tcp_offsets.find(manipulator.toStdString());
-    if (it != group_tcp_offsets.end())
-    {
-      available_tcp_offsets_ = it->second;
-      for (const auto& tcp_offset : available_tcp_offsets_)
-        tcp_frame_property_->addOptionStd(tcp_offset.first);
-    }
-
-    if (current_tcp_frame.isEmpty() || !available_tcp_frames_.contains(current_tcp_frame))
-      tcp_frame_property_->setString(available_tcp_frames_[0]);
-    else
-      tcp_frame_property_->setString(current_tcp_frame);
-
-    Q_EMIT availableTCPFramesChanged(available_tcp_frames_);
-
-    if (current_tcp_offset.isEmpty() ||
-        (available_tcp_offsets_.find(current_tcp_offset.toStdString()) == available_tcp_offsets_.end()))
-    {
-      if (available_tcp_offsets_.empty())
-      {
-        tcp_offset_property_->setStdString("");
-        tcp_offset_ = Eigen::Isometry3d::Identity();
-      }
-      else
-      {
-        tcp_offset_property_->setStdString(available_tcp_offsets_.begin()->first);
-        tcp_offset_ = available_tcp_offsets_.begin()->second;
-      }
+      tcp_property_->setStdString(inv_kin_->getTipLinkName());
+      tcp_ = Eigen::Isometry3d::Identity();
     }
     else
     {
-      tcp_offset_property_->setString(current_tcp_offset);
-      tcp_offset_ = available_tcp_offsets_.at(current_tcp_offset.toStdString());
+      tcp_property_->setString(current_tcp);
+      tcp_ = env_state_->link_transforms[inv_kin_->getTipLinkName()].inverse() *
+             env_state_->link_transforms[current_tcp.toStdString()];
     }
 
-    Q_EMIT availableTCPOffsetsChanged(available_tcp_offsets_);
-
-    if (current_robot_config_base_link.isEmpty() || !available_working_frames_.contains(current_robot_config_base_link))
-      joint_config_base_link_property_->setString(available_working_frames_[0]);
-    else
-      joint_config_base_link_property_->setString(current_robot_config_base_link);
-
-    if (current_robot_config_tip_link.isEmpty() || !available_tcp_frames_.contains(current_robot_config_tip_link))
-      joint_config_tip_link_property_->setString(available_tcp_frames_[0]);
-    else
-      joint_config_tip_link_property_->setString(current_robot_config_tip_link);
+    Q_EMIT availableTCPLinksChanged(available_tcp_links_);
 
     // Add 6 DOF interactive marker at the end of the manipulator
     interactive_marker_ = boost::make_shared<InteractiveMarker>("6DOF",
                                                                 "Move Robot",
-                                                                env_->getRootLinkName(),
+                                                                tesseract_->getEnvironmentConst()->getRootLinkName(),
                                                                 root_interactive_node_,
                                                                 context_,
                                                                 true,
                                                                 cartesian_marker_scale_property_->getFloat());
     make6Dof(*interactive_marker_);
 
-    Eigen::Isometry3d pose =
-        env_state_.link_transforms.at(tcp_frame_property_->getString().toStdString()) * tcp_offset_;
+    Eigen::Isometry3d pose = env_state_->link_transforms[inv_kin_->getTipLinkName()] * tcp_;
     Ogre::Vector3 position;
     Ogre::Quaternion orientation;
     toOgre(position, orientation, pose);
@@ -420,20 +344,20 @@ bool ManipulationWidget::changeManipulator(const QString& manipulator)
     interactive_marker_->setVisible(enabled_ && cartesian_manipulation_property_->getBool());
 
     connect(interactive_marker_.get(),
-            SIGNAL(userFeedback(std::string, const Eigen::Isometry3d&, const Eigen::Vector3d&, bool)),
+            SIGNAL(userFeedback(std::string, Eigen::Isometry3d, Eigen::Vector3d, bool)),
             this,
-            SLOT(markerFeedback(std::string, const Eigen::Isometry3d&, const Eigen::Vector3d&, bool)));
+            SLOT(markerFeedback(std::string, Eigen::Isometry3d, Eigen::Vector3d, bool)));
 
     // Add joint specific interactive marker
     joint_interactive_markers_.clear();
-    for (const auto& joint_name : manip_->getJointNames())
+    for (const auto& joint_name : inv_kin_->getJointNames())
     {
       std::string name = joint_name + "_interactive_marker";
       std::string disc = "Move joint: " + joint_name;
-      InteractiveMarker::Ptr interactive_marker =
+      InteractiveMarker::SharedPtr interactive_marker =
           boost::make_shared<InteractiveMarker>(name,
                                                 disc,
-                                                env_->getRootLinkName(),
+                                                tesseract_->getEnvironmentConst()->getRootLinkName(),
                                                 root_interactive_node_,
                                                 context_,
                                                 true,
@@ -447,7 +371,7 @@ bool ManipulationWidget::changeManipulator(const QString& manipulator)
           Eigen::Vector3d disc_axis(1, 0, 0);
           Eigen::Quaternionf q = Eigen::Quaterniond::FromTwoVectors(disc_axis, joint->axis).cast<float>();
 
-          InteractiveMarkerControl::Ptr control =
+          InteractiveMarkerControl::SharedPtr control =
               interactive_marker->createInteractiveControl("move_" + joint_name,
                                                            "Move prismatic joint: " + joint_name,
                                                            InteractiveMode::MOVE_AXIS,
@@ -463,22 +387,7 @@ bool ManipulationWidget::changeManipulator(const QString& manipulator)
         {
           Eigen::Vector3d disc_axis(1, 0, 0);
           Eigen::Quaternionf q = Eigen::Quaterniond::FromTwoVectors(disc_axis, joint->axis).cast<float>();
-          InteractiveMarkerControl::Ptr control =
-              interactive_marker->createInteractiveControl("rotate_x",
-                                                           "Rotate around X Axis",
-                                                           InteractiveMode::ROTATE_AXIS,
-                                                           OrientationMode::INHERIT,
-                                                           true,
-                                                           Ogre::Quaternion(q.w(), q.x(), q.y(), q.z()));
-          makeDisc(*control, 0.3f);
-          joint_interactive_markers_[joint_name] = interactive_marker;
-          break;
-        }
-        case tesseract_scene_graph::JointType::CONTINUOUS:
-        {
-          Eigen::Vector3d disc_axis(1, 0, 0);
-          Eigen::Quaternionf q = Eigen::Quaterniond::FromTwoVectors(disc_axis, joint->axis).cast<float>();
-          InteractiveMarkerControl::Ptr control =
+          InteractiveMarkerControl::SharedPtr control =
               interactive_marker->createInteractiveControl("rotate_x",
                                                            "Rotate around X Axis",
                                                            InteractiveMode::ROTATE_AXIS,
@@ -493,7 +402,7 @@ bool ManipulationWidget::changeManipulator(const QString& manipulator)
           assert(false);
       }
 
-      Eigen::Isometry3d pose = env_state_.link_transforms.at(joint->child_link_name);
+      Eigen::Isometry3d pose = env_state_->link_transforms[joint->child_link_name];
       Ogre::Vector3 position;
       Ogre::Quaternion orientation;
       toOgre(position, orientation, pose);
@@ -519,61 +428,32 @@ bool ManipulationWidget::changeManipulator(const QString& manipulator)
   return false;
 }
 
-bool ManipulationWidget::changeTCPFrame(const QString& tcp_frame)
+bool ManipulationWidget::changeTCP(QString tcp_link)
 {
   bool success = false;
-  if (tcp_frame.isEmpty() || !available_tcp_frames_.contains(tcp_frame))
+  if (!env_state_ || tcp_link.isEmpty() || !available_tcp_links_.contains(tcp_link))
   {
-    if (manip_)
-    {
-      if (available_tcp_frames_.empty())
-        tcp_frame_property_->setString("");
-      else
-        tcp_frame_property_->setString(available_tcp_frames_[0]);
-    }
-  }
-  else
-  {
-    tcp_frame_property_->setString(tcp_frame);
-    success = true;
-  }
+    if (inv_kin_)
+      tcp_property_->setStdString(inv_kin_->getTipLinkName());
 
-  if (manip_ && !env_state_.link_transforms.empty() && interactive_marker_)
-  {
-    updateCartesianMarkerVisualization();
-  }
-
-  return success;
-}
-
-bool ManipulationWidget::changeTCPOffset(const QString& tcp_offset)
-{
-  bool success = false;
-  if (tcp_offset.isEmpty() || (available_tcp_offsets_.find(tcp_offset.toStdString()) == available_tcp_offsets_.end()))
-  {
-    if (available_tcp_offsets_.empty())
-    {
-      tcp_offset_property_->setString("");
-      tcp_offset_ = Eigen::Isometry3d::Identity();
-    }
-    else
-    {
-      tcp_offset_property_->setStdString(available_tcp_offsets_.begin()->first);
-      tcp_offset_ = available_tcp_offsets_.begin()->second;
-    }
-
+    tcp_ = Eigen::Isometry3d::Identity();
     success = false;
   }
   else
   {
-    tcp_offset_property_->setString(tcp_offset);
-    tcp_offset_ = available_tcp_offsets_.at(tcp_offset.toStdString());
+    tcp_property_->setString(tcp_link);
+    tcp_ = env_state_->link_transforms[inv_kin_->getTipLinkName()].inverse() *
+           env_state_->link_transforms[tcp_link.toStdString()];
     success = true;
   }
 
-  if (manip_ && !env_state_.link_transforms.empty() && interactive_marker_)
+  if (inv_kin_ && env_state_ && interactive_marker_)
   {
-    updateCartesianMarkerVisualization();
+    Eigen::Isometry3d pose = env_state_->link_transforms[inv_kin_->getTipLinkName()] * tcp_;
+    Ogre::Vector3 position;
+    Ogre::Quaternion orientation;
+    toOgre(position, orientation, pose);
+    interactive_marker_->setPose(position, orientation, "");
   }
 
   return success;
@@ -602,8 +482,7 @@ void ManipulationWidget::changedManipulator()
   //  }
 }
 
-void ManipulationWidget::changedTCPFrame() { changeTCPFrame(tcp_frame_property_->getString()); }
-void ManipulationWidget::changedTCPOffset() { changeTCPOffset(tcp_offset_property_->getString()); }
+void ManipulationWidget::changedTCP() { changeTCP(tcp_property_->getString()); }
 
 void ManipulationWidget::changedCartesianMarkerScale()
 {
@@ -636,58 +515,99 @@ void ManipulationWidget::changedJointStateTopic()
   }
 }
 
-void ManipulationWidget::markerFeedback(const std::string& reference_frame,
-                                        const Eigen::Isometry3d& transform,
-                                        const Eigen::Vector3d& /*mouse_point*/,
-                                        bool /*mouse_point_valid*/)
+void ManipulationWidget::markerFeedback(std::string reference_frame,
+                                        Eigen::Isometry3d transform,
+                                        Eigen::Vector3d mouse_point,
+                                        bool mouse_point_valid)
 {
-  if (manip_ && !env_state_.link_transforms.empty())
+  if (inv_kin_ && env_state_)
   {
-    tesseract_kinematics::KinGroupIKInput ik_input(
-        transform * tcp_offset_.inverse(), reference_frame, tcp_frame_property_->getStdString());
-    tesseract_kinematics::IKSolutions solutions = manip_->calcInvKin({ ik_input }, inv_seed_);
-    if (!solutions.empty())
+    const Eigen::Isometry3d& ref = env_state_->link_transforms[reference_frame];
+    const Eigen::Isometry3d& base = env_state_->link_transforms[inv_kin_->getBaseLinkName()];
+
+    Eigen::Isometry3d local_tf = (base.inverse() * ref * transform) * tcp_.inverse();
+    Eigen::VectorXd solutions;
+    if (inv_kin_->calcInvKin(solutions, local_tf, inv_seed_))
     {
-      const Eigen::VectorXd& temp_seed = solutions[0];
-      if (!tesseract_common::satisfiesPositionLimits(temp_seed, manip_->getLimits().joint_limits))
+      Eigen::VectorXd temp_seed = solutions.head(inv_kin_->numJoints());
+      if (!tesseract_kinematics::isWithinLimits(temp_seed, inv_kin_->getLimits()))
         return;
 
       inv_seed_ = temp_seed;
       int i = 0;
-      for (const auto& j : manip_->getJointNames())
+      for (auto j : inv_kin_->getJointNames())
       {
         joints_[j] = inv_seed_[i];
-        bool oldState = joint_values_property_->childAt(i)->blockSignals(true);
         joint_values_property_->childAt(i)->setValue(inv_seed_[i]);
-        joint_values_property_->childAt(i)->blockSignals(oldState);
-
         ++i;
       }
 
-      env_state_ = env_->getState(joints_);
-      updateJointConfig();
-      updateEnvironmentVisualization();
-      updateCartesianMarkerVisualization();
-      udpateJointMarkerVisualization();
-      publishJointStates();
-    }
-    else
-    {
-      updateCartesianMarkerVisualization();
+      env_state_ = tesseract_->getEnvironmentConst()->getState(joints_);
+      if (state_ == ManipulatorState::START)
+      {
+        for (auto& link_pair : visualization_->getLinks())
+        {
+          LinkWidget* link = link_pair.second;
+          auto it = env_state_->link_transforms.find(link->getName());
+          if (it != env_state_->link_transforms.end())
+          {
+            link->setStartTransform(it->second);
+          }
+        }
+
+        const auto& scene_graph = tesseract_->getEnvironmentConst()->getSceneGraph();
+        for (auto& joint_marker : joint_interactive_markers_)
+        {
+          const auto& joint = scene_graph->getJoint(joint_marker.first);
+          Eigen::Isometry3d pose = env_state_->link_transforms[joint->child_link_name];
+          Ogre::Vector3 position;
+          Ogre::Quaternion orientation;
+          toOgre(position, orientation, pose);
+
+          joint_marker.second->setPose(position, orientation, "");
+        }
+      }
+      else
+      {
+        for (auto& link_pair : visualization_->getLinks())
+        {
+          LinkWidget* link = link_pair.second;
+          auto it = env_state_->link_transforms.find(link->getName());
+          if (it != env_state_->link_transforms.end())
+          {
+            link->setEndTransform(it->second);
+          }
+        }
+
+        const auto& scene_graph = tesseract_->getEnvironmentConst()->getSceneGraph();
+        for (auto& joint_marker : joint_interactive_markers_)
+        {
+          const auto& joint = scene_graph->getJoint(joint_marker.first);
+          Eigen::Isometry3d pose = env_state_->link_transforms[joint->child_link_name];
+          Ogre::Vector3 position;
+          Ogre::Quaternion orientation;
+          toOgre(position, orientation, pose);
+
+          joint_marker.second->setPose(position, orientation, "");
+        }
+      }
+      sensor_msgs::JointState joint_state;
+      tesseract_rosutils::toMsg(joint_state, *env_state_);
+      joint_state_pub_.publish(joint_state);
     }
   }
 }
 
-void ManipulationWidget::jointMarkerFeedback(const std::string& joint_name,
-                                             const std::string& /*reference_frame*/,
-                                             const Eigen::Isometry3d& transform,
-                                             const Eigen::Vector3d& /*mouse_point*/,
-                                             bool /*mouse_point_valid*/)
+void ManipulationWidget::jointMarkerFeedback(std::string joint_name,
+                                             std::string reference_frame,
+                                             Eigen::Isometry3d transform,
+                                             Eigen::Vector3d mouse_point,
+                                             bool mouse_point_valid)
 {
-  const auto& scene_graph = env_->getSceneGraph();
+  const auto& scene_graph = tesseract_->getEnvironmentConst()->getSceneGraph();
   const auto& joint = scene_graph->getJoint(joint_name);
-  double current_joint_value = env_state_.joints.at(joint_name);
-  Eigen::Isometry3d child_pose = env_state_.link_transforms.at(joint->child_link_name);
+  double current_joint_value = env_state_->joints[joint_name];
+  Eigen::Isometry3d child_pose = env_state_->link_transforms[joint->child_link_name];
   Eigen::Isometry3d delta_pose = child_pose.inverse() * transform;
 
   Eigen::Vector3d delta_axis;
@@ -709,15 +629,6 @@ void ManipulationWidget::jointMarkerFeedback(const std::string& joint_name,
       delta_joint_value = delta_rotation.angle();
       break;
     }
-    case tesseract_scene_graph::JointType::CONTINUOUS:
-    {
-      Eigen::AngleAxisd delta_rotation;
-      delta_rotation.fromRotationMatrix(delta_pose.rotation());
-
-      delta_axis = delta_rotation.axis();
-      delta_joint_value = delta_rotation.angle();
-      break;
-    }
     default:
       assert(false);
   }
@@ -728,109 +639,175 @@ void ManipulationWidget::jointMarkerFeedback(const std::string& joint_name,
   else
     new_joint_value = current_joint_value - delta_joint_value;
 
-  Eigen::MatrixX2d limits = manip_->getLimits().joint_limits;
+  if (joint->limits)
+  {
+    if (new_joint_value > joint->limits->upper)
+    {
+      new_joint_value = joint->limits->upper;
+    }
+    else if (new_joint_value < joint->limits->lower)
+    {
+      new_joint_value = joint->limits->lower;
+    }
+  }
+
   int i = 0;
-  for (const auto& j : manip_->getJointNames())
+  for (auto j : inv_kin_->getJointNames())
   {
     if (joint_name == j)
     {
-      if (new_joint_value > limits(i, 1))
-      {
-        new_joint_value = limits(i, 1);
-      }
-      else if (new_joint_value < limits(i, 0))
-      {
-        new_joint_value = limits(i, 0);
-      }
-
       joints_[j] = new_joint_value;
       inv_seed_[i] = new_joint_value;
-
-      bool oldState = joint_values_property_->childAt(i)->blockSignals(true);
       joint_values_property_->childAt(i)->setValue(inv_seed_[i]);
-      joint_values_property_->childAt(i)->blockSignals(oldState);
       break;
     }
 
     ++i;
   }
 
-  env_state_ = env_->getState(joints_);
-  updateJointConfig();
-  updateEnvironmentVisualization();
-  updateCartesianMarkerVisualization();
-  udpateJointMarkerVisualization();
-  publishJointStates();
-}
-
-void ManipulationWidget::userInputJointValuesChanged()
-{
-  if (joint_values_property_->numChildren() != static_cast<int>(manip_->numJoints()))
-    return;
-
-  int i = 0;
-  for (const auto& j : manip_->getJointNames())
+  env_state_ = tesseract_->getEnvironmentConst()->getState(joints_);
+  if (state_ == ManipulatorState::START)
   {
-    double new_joint_value = joint_values_property_->childAt(i)->getValue().toDouble();
+    for (auto& link_pair : visualization_->getLinks())
+    {
+      LinkWidget* link = link_pair.second;
+      auto it = env_state_->link_transforms.find(link->getName());
+      if (it != env_state_->link_transforms.end())
+      {
+        link->setStartTransform(it->second);
+      }
+    }
 
-    joints_[j] = new_joint_value;
-    inv_seed_[i] = new_joint_value;
+    const auto& scene_graph = tesseract_->getEnvironmentConst()->getSceneGraph();
+    for (auto& joint_marker : joint_interactive_markers_)
+    {
+      const auto& joint = scene_graph->getJoint(joint_marker.first);
+      Eigen::Isometry3d pose = env_state_->link_transforms[joint->child_link_name];
+      Ogre::Vector3 position;
+      Ogre::Quaternion orientation;
+      toOgre(position, orientation, pose);
 
-    ++i;
+      joint_marker.second->setPose(position, orientation, "");
+    }
+  }
+  else
+  {
+    for (auto& link_pair : visualization_->getLinks())
+    {
+      LinkWidget* link = link_pair.second;
+      auto it = env_state_->link_transforms.find(link->getName());
+      if (it != env_state_->link_transforms.end())
+      {
+        link->setEndTransform(it->second);
+      }
+    }
+
+    const auto& scene_graph = tesseract_->getEnvironmentConst()->getSceneGraph();
+    for (auto& joint_marker : joint_interactive_markers_)
+    {
+      const auto& joint = scene_graph->getJoint(joint_marker.first);
+      Eigen::Isometry3d pose = env_state_->link_transforms[joint->child_link_name];
+      Ogre::Vector3 position;
+      Ogre::Quaternion orientation;
+      toOgre(position, orientation, pose);
+
+      joint_marker.second->setPose(position, orientation, "");
+    }
   }
 
-  env_state_ = env_->getState(joints_);
-  updateJointConfig();
-  updateEnvironmentVisualization();
-  updateCartesianMarkerVisualization();
-  udpateJointMarkerVisualization();
-  publishJointStates();
+  Eigen::Isometry3d pose = env_state_->link_transforms[inv_kin_->getTipLinkName()] * tcp_;
+  Ogre::Vector3 position;
+  Ogre::Quaternion orientation;
+  toOgre(position, orientation, pose);
+  interactive_marker_->setPose(position, orientation, "");
+
+  sensor_msgs::JointState joint_state;
+  tesseract_rosutils::toMsg(joint_state, *env_state_);
+  joint_state_pub_.publish(joint_state);
 }
 
 void ManipulationWidget::onUpdate(float wall_dt)
 {
-  if (!env_->isInitialized() || !visualization_)
+  if (!tesseract_->isInitialized() || !visualization_)
     return;
 
-  if (env_->isInitialized())
+  if (tesseract_->isInitialized())
   {
-    if (env_revision_ != env_->getRevision() || env_state_.link_transforms.empty())
+    if (env_revision_ != tesseract_->getEnvironmentConst()->getRevision() || !env_state_)
     {
-      env_revision_ = env_->getRevision();
-      env_state_ = env_->getState();
-      joints_ = env_state_.joints;
-      updateEnvironmentVisualization();
-
-      if (manip_)
+      env_revision_ = tesseract_->getEnvironmentConst()->getRevision();
+      env_state_ =
+          std::make_shared<tesseract_environment::EnvState>(*(tesseract_->getEnvironmentConst()->getCurrentState()));
+      joints_ = env_state_->joints;
+      if (state_ == ManipulatorState::START)
       {
-        inv_seed_.resize(manip_->numJoints());
+        for (auto& link_pair : visualization_->getLinks())
+        {
+          LinkWidget* link = link_pair.second;
+          auto it = env_state_->link_transforms.find(link->getName());
+          if (it != env_state_->link_transforms.end())
+          {
+            link->setStartTransform(it->second);
+          }
+        }
+      }
+      else
+      {
+        for (auto& link_pair : visualization_->getLinks())
+        {
+          LinkWidget* link = link_pair.second;
+          auto it = env_state_->link_transforms.find(link->getName());
+          if (it != env_state_->link_transforms.end())
+          {
+            link->setEndTransform(it->second);
+          }
+        }
+      }
+      if (inv_kin_)
+      {
+        inv_seed_.resize(inv_kin_->numJoints());
         int i = 0;
-        for (const auto& j : manip_->getJointNames())
+        for (auto j : inv_kin_->getJointNames())
         {
           inv_seed_[i] = joints_[j];
-          bool oldState = joint_values_property_->childAt(i)->blockSignals(true);
           joint_values_property_->childAt(i)->setValue(inv_seed_[i]);
-          joint_values_property_->childAt(i)->blockSignals(oldState);
           ++i;
         }
-        updateJointConfig();
-        updateCartesianMarkerVisualization();
-        udpateJointMarkerVisualization();
+
+        Eigen::Isometry3d pose = env_state_->link_transforms[inv_kin_->getTipLinkName()] * tcp_;
+        Ogre::Vector3 position;
+        Ogre::Quaternion orientation;
+        toOgre(position, orientation, pose);
+        interactive_marker_->setPose(position, orientation, "");
+
+        const auto& scene_graph = tesseract_->getEnvironmentConst()->getSceneGraph();
+        for (auto& joint_marker : joint_interactive_markers_)
+        {
+          const auto& joint = scene_graph->getJoint(joint_marker.first);
+
+          Eigen::Isometry3d pose = env_state_->link_transforms[joint->child_link_name];
+          Ogre::Vector3 position;
+          Ogre::Quaternion orientation;
+          toOgre(position, orientation, pose);
+
+          joint_marker.second->setPose(position, orientation, "");
+        }
       }
     }
 
-    if (!manip_)
+    if (!inv_kin_)
       changedManipulator();
 
     std::string current_manipulator = manipulator_property_->getStdString();
-    std::set<std::string> manipulators = env_->getGroupNames();
+    std::vector<std::string> manipulators =
+        tesseract_->getInvKinematicsManagerConst()->getAvailableInvKinematicsManipulators();
 
     if (manipulators_.size() != manipulators.size() && !manipulators.empty())
     {
       int cnt = 0;
       manipulator_property_->clearOptions();
       available_manipulators_.clear();
-      for (const auto& manip : manipulators)
+      for (const auto& manip : tesseract_->getInvKinematicsManagerConst()->getAvailableInvKinematicsManipulators())
       {
         available_manipulators_.push_back(QString::fromStdString(manip));
         manipulator_property_->addOptionStd(manip, cnt);
@@ -839,7 +816,7 @@ void ManipulationWidget::onUpdate(float wall_dt)
       auto it = std::find(manipulators.begin(), manipulators.end(), current_manipulator);
 
       if (it == manipulators.end())
-        manipulator_property_->setStringStd(*std::next(manipulators.begin(), 0));
+        manipulator_property_->setStringStd(manipulators[0]);
       else
         manipulator_property_->setStringStd(current_manipulator);
 
@@ -853,90 +830,6 @@ void ManipulationWidget::onUpdate(float wall_dt)
 
   for (auto& joint_marker : joint_interactive_markers_)
     joint_marker.second->update(wall_dt);
-}
-
-void ManipulationWidget::updateJointConfig()
-{
-  // calculate robot config
-  if (manip_->numJoints() == 6)
-  {
-    Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, "", "");
-
-    Eigen::Vector2i sign_correction;
-    sign_correction[0] = joint3_sign_property_->getOptionInt();
-    sign_correction[1] = joint5_sign_property_->getOptionInt();
-
-    auto config = tesseract_planning::getRobotConfig<double>(*manip_,
-                                                             joint_config_base_link_property_->getStdString(),
-                                                             joint_config_tip_link_property_->getStdString(),
-                                                             inv_seed_,
-                                                             sign_correction);
-    Eigen::VectorXi turns = tesseract_planning::getJointTurns<double>(inv_seed_).transpose();
-
-    std::stringstream config_string;
-    config_string << tesseract_planning::RobotConfigString[static_cast<std::size_t>(config)];
-    config_string << " " << turns.format(eigen_format);
-    joint_config_property_->setStdString(config_string.str());
-  }
-  else
-  {
-    joint_config_property_->setString("Unknown");
-  }
-}
-
-void ManipulationWidget::updateEnvironmentVisualization()
-{
-  if (state_ == ManipulatorState::START)
-  {
-    for (auto& link_pair : visualization_->getLinks())
-    {
-      LinkWidget* link = link_pair.second;
-      auto it = env_state_.link_transforms.find(link->getName());
-      if (it != env_state_.link_transforms.end())
-        link->setStartTransform(it->second);
-    }
-  }
-  else
-  {
-    for (auto& link_pair : visualization_->getLinks())
-    {
-      LinkWidget* link = link_pair.second;
-      auto it = env_state_.link_transforms.find(link->getName());
-      if (it != env_state_.link_transforms.end())
-        link->setEndTransform(it->second);
-    }
-  }
-}
-
-void ManipulationWidget::updateCartesianMarkerVisualization()
-{
-  Eigen::Isometry3d pose = env_state_.link_transforms.at(tcp_frame_property_->getString().toStdString()) * tcp_offset_;
-  Ogre::Vector3 position;
-  Ogre::Quaternion orientation;
-  toOgre(position, orientation, pose);
-  interactive_marker_->setPose(position, orientation, "");
-}
-
-void ManipulationWidget::udpateJointMarkerVisualization()
-{
-  const auto& scene_graph = env_->getSceneGraph();
-  for (auto& joint_marker : joint_interactive_markers_)
-  {
-    const auto& joint = scene_graph->getJoint(joint_marker.first);
-    Eigen::Isometry3d pose = env_state_.link_transforms.at(joint->child_link_name);
-    Ogre::Vector3 position;
-    Ogre::Quaternion orientation;
-    toOgre(position, orientation, pose);
-
-    joint_marker.second->setPose(position, orientation, "");
-  }
-}
-
-void ManipulationWidget::publishJointStates()
-{
-  sensor_msgs::JointState joint_state;
-  tesseract_rosutils::toMsg(joint_state, env_state_.joints);
-  joint_state_pub_.publish(joint_state);
 }
 
 // void TrajectoryMonitorWidget::trajectorySliderPanelVisibilityChange(bool enable)

--- a/tesseract_rviz/src/render_tools/trajectory_monitor_widget.cpp
+++ b/tesseract_rviz/src/render_tools/trajectory_monitor_widget.cpp
@@ -36,24 +36,22 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <memory>
-
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/lexical_cast.hpp>
 
-#include <rviz/display_context.h>
-#include <rviz/properties/bool_property.h>
-#include <rviz/properties/color_property.h>
-#include <rviz/properties/editable_enum_property.h>
-#include <rviz/properties/enum_property.h>
-#include <rviz/properties/float_property.h>
-#include <rviz/properties/int_property.h>
-#include <rviz/properties/property.h>
-#include <rviz/properties/ros_topic_property.h>
-#include <rviz/properties/string_property.h>
-#include <rviz/window_manager_interface.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/properties/bool_property.hpp>
+#include <rviz_common/properties/color_property.hpp>
+#include <rviz_common/properties/editable_enum_property.hpp>
+#include <rviz_common/properties/enum_property.hpp>
+#include <rviz_common/properties/float_property.hpp>
+#include <rviz_common/properties/int_property.hpp>
+#include <rviz_common/properties/property.hpp>
+#include <rviz_common/properties/ros_topic_property.hpp>
+#include <rviz_common/properties/string_property.hpp>
+#include <rviz_common/window_manager_interface.hpp>
 
-#include <tesseract_command_language/utils/utils.h>
 #include <tesseract_rosutils/utils.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
@@ -63,68 +61,464 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_rviz
 {
-const double SLIDER_RESOLUTION = 0.001;
-
-TrajectoryMonitorWidget::TrajectoryMonitorWidget(rviz::Property* widget, rviz::Display* display)
+TrajectoryMonitorWidget::TrajectoryMonitorWidget(rviz_common::properties::Property* widget, rviz_common::Display* display)
   : widget_(widget)
   , display_(display)
-  , visualize_trajectory_widget_(std::make_shared<VisualizeTrajectoryWidget>(widget, display))  // should widget be
-                                                                                                // this?
+  , tesseract_(nullptr)
+  , visualization_(nullptr)
+  , animating_path_(false)
+  , drop_displaying_trajectory_(false)
+  , current_state_(-1)
+  , trajectory_slider_panel_(nullptr)
+  , trajectory_slider_dock_panel_(nullptr)
+  , cached_visible_(false)
 {
-  main_property_ = new rviz::Property(
+  main_property_ = new rviz_common::properties::Property(
       "Trajectory Monitor", "", "Monitor a joint state topic and update the visualization", widget_, nullptr, this);
 
-  trajectory_topic_property_ = new rviz::RosTopicProperty("Topic",
+  trajectory_topic_property_ = new rviz_common::properties::RosTopicProperty("Topic",
                                                           "/tesseract/display_tesseract_trajectory",
-                                                          ros::message_traits::datatype<tesseract_msgs::Trajectory>(),
-                                                          "The topic on which the tesseract_msgs::Trajectory messages "
+                                                          "tesseract_msgs::msg::Trajectory",
+                                                          "The topic on which the tesseract_msgs::msg::Trajectory messages "
                                                           "are received",
                                                           main_property_,
                                                           SLOT(changedTrajectoryTopic()),
                                                           this);
+
+  display_mode_property_ = new rviz_common::properties::EnumProperty(
+      "Display Mode", "Loop", "How to display the trajectoy.", main_property_, SLOT(changedDisplayMode()), this);
+  display_mode_property_->addOptionStd("Single", 0);
+  display_mode_property_->addOptionStd("Loop", 1);
+  display_mode_property_->addOptionStd("Trail", 2);
+
+  state_display_time_property_ = new rviz_common::properties::EditableEnumProperty("State Display Time",
+                                                                "0.05 s",
+                                                                "The amount of wall-time to wait in between displaying "
+                                                                "states along a received trajectory path",
+                                                                main_property_,
+                                                                SLOT(changedStateDisplayTime()),
+                                                                this);
+  state_display_time_property_->addOptionStd("REALTIME");
+  state_display_time_property_->addOptionStd("0.05 s");
+  state_display_time_property_->addOptionStd("0.1 s");
+  state_display_time_property_->addOptionStd("0.5 s");
+
+  trail_step_size_property_ = new rviz_common::properties::IntProperty("Trail Step Size",
+                                                    1,
+                                                    "Specifies the step size of the samples "
+                                                    "shown in the trajectory trail.",
+                                                    main_property_,
+                                                    SLOT(changedTrailStepSize()),
+                                                    this);
+  trail_step_size_property_->setMin(1);
+
+  interrupt_display_property_ = new rviz_common::properties::BoolProperty("Interrupt Display",
+                                                       false,
+                                                       "Immediately show newly planned trajectory, "
+                                                       "interrupting the currently displayed one.",
+                                                       main_property_);
 }
 
-TrajectoryMonitorWidget::~TrajectoryMonitorWidget() {}
+TrajectoryMonitorWidget::~TrajectoryMonitorWidget()
+{
+  clearTrajectoryTrail();
+  trajectory_message_to_display_.reset();
+  displaying_trajectory_message_.reset();
 
-void TrajectoryMonitorWidget::onInitialize(VisualizationWidget::Ptr visualization,
-                                           tesseract_environment::Environment::Ptr env,
-                                           rviz::DisplayContext* context,
-                                           const ros::NodeHandle& update_nh)
+  if (trajectory_slider_dock_panel_)
+    delete trajectory_slider_dock_panel_;
+}
+
+void TrajectoryMonitorWidget::onInitialize(VisualizationWidget::SharedPtr visualization,
+                                           tesseract::Tesseract::Ptr tesseract,
+                                           rviz_common::DisplayContext* context,
+                                           rclcpp::Node::SharedPtr update_node)
 {
   // Save pointers for later use
+  visualization_ = std::move(visualization);
+  tesseract_ = std::move(tesseract);
   context_ = context;
-  nh_ = update_nh;
+  node_ = update_node;
 
-  visualize_trajectory_widget_->onInitialize(visualization, env, context);
+  previous_display_mode_ = display_mode_property_->getOptionInt();
+
+  auto rviz_ros_node = context->getRosNodeAbstraction();
+  trajectory_topic_property_->initialize(rviz_ros_node);
+
+  rviz_common::WindowManagerInterface* window_context = context_->getWindowManager();
+  if (window_context)
+  {
+    trajectory_slider_panel_ = new TrajectoryPanel(window_context->getParentWindow());
+    trajectory_slider_dock_panel_ =
+        window_context->addPane(display_->getName() + " - Slider", trajectory_slider_panel_);
+    trajectory_slider_dock_panel_->setIcon(display_->getIcon());
+    connect(trajectory_slider_dock_panel_,
+            SIGNAL(visibilityChanged(bool)),
+            this,
+            SLOT(trajectorySliderPanelVisibilityChange(bool)));
+    trajectory_slider_panel_->onInitialize();
+  }
 }
 
 void TrajectoryMonitorWidget::onEnable()
 {
-  visualize_trajectory_widget_->onEnable();
-  changedTrajectoryTopic();
+  visualization_->setTrajectoryVisible(cached_visible_);
+  changedTrajectoryTopic();  // load topic at startup if default used
 }
 
-void TrajectoryMonitorWidget::onDisable() { visualize_trajectory_widget_->onDisable(); }
-
-void TrajectoryMonitorWidget::onUpdate(float wall_dt) { visualize_trajectory_widget_->onUpdate(wall_dt); }
-
-void TrajectoryMonitorWidget::onReset() { visualize_trajectory_widget_->onReset(); }
-
-void TrajectoryMonitorWidget::onNameChange(const QString& name) { visualize_trajectory_widget_->onNameChange(name); }
-
-void TrajectoryMonitorWidget::changedTrajectoryTopic()
+void TrajectoryMonitorWidget::onDisable()
 {
-  trajectory_topic_sub_.shutdown();
-  if (!trajectory_topic_property_->getStdString().empty())
+  cached_visible_ = visualization_->isTrajectoryVisible();
+  visualization_->setTrajectoryVisible(false);
+  displaying_trajectory_message_.reset();
+  animating_path_ = false;
+
+  if (trajectory_slider_panel_)
+    trajectory_slider_panel_->onDisable();
+}
+
+void TrajectoryMonitorWidget::onReset()
+{
+  clearTrajectoryTrail();
+  trajectory_message_to_display_.reset();
+  displaying_trajectory_message_.reset();
+  animating_path_ = false;
+}
+
+void TrajectoryMonitorWidget::onNameChange(const QString& name)
+{
+  if (trajectory_slider_dock_panel_)
+    trajectory_slider_dock_panel_->setWindowTitle(name + " - Slider");
+}
+
+void TrajectoryMonitorWidget::clearTrajectoryTrail()
+{
+  for (auto& link_pair : visualization_->getLinks())
+    link_pair.second->clearTrajectory();
+}
+
+void TrajectoryMonitorWidget::createTrajectoryTrail()
+{
+  clearTrajectoryTrail();
+
+  tesseract_msgs::msg::Trajectory::SharedPtr t = trajectory_message_to_display_;
+  if (!t)
+    t = displaying_trajectory_message_;
+
+  if (!t)
+    return;
+
+  int stepsize = trail_step_size_property_->getInt();
+  // always include last trajectory point
+  int num_waypoints = static_cast<int>(t->joint_trajectory.points.size());
+  num_trajectory_waypoints_ =
+      static_cast<size_t>(std::ceil(static_cast<float>(num_waypoints + stepsize - 1) / static_cast<float>(stepsize)));
+  std::vector<tesseract_environment::EnvState::Ptr> states_data;
+  states_data.reserve(num_trajectory_waypoints_);
+  for (std::size_t i = 0; i < num_trajectory_waypoints_; i++)
   {
-    trajectory_topic_sub_ = nh_.subscribe(
-        trajectory_topic_property_->getStdString(), 5, &TrajectoryMonitorWidget::incomingDisplayTrajectory, this);
+    unsigned waypoint_i = static_cast<unsigned>(std::min(
+        i * static_cast<size_t>(stepsize), static_cast<size_t>(num_waypoints - 1)));  // limit to last trajectory point
+
+    std::unordered_map<std::string, double> joints;
+    for (unsigned j = 0; j < t->joint_trajectory.joint_names.size(); ++j)
+    {
+      joints[t->joint_trajectory.joint_names[j]] = t->joint_trajectory.points[waypoint_i].positions[j];
+    }
+
+    states_data.push_back(tesseract_->getEnvironment()->getState(joints));
+  }
+
+  // If current state is not visible must set trajectory for all links for a single state so static
+  // objects will be visible
+  for (const auto& tf : states_data[0]->link_transforms)
+  {
+    LinkWidget* lw = visualization_->getLink(tf.first);
+    lw->clearTrajectory();
+
+    if (!visualization_->isCurrentStateVisible())
+      lw->setTrajectory({ tf.second });
+  }
+
+  // Set Trajectory for active links
+  for (const auto& link_name : tesseract_->getEnvironment()->getActiveLinkNames())
+  {
+    std::vector<Eigen::Isometry3d> link_trajectory;
+    link_trajectory.reserve(states_data.size());
+    for (auto& state : states_data)
+    {
+      link_trajectory.push_back(state->link_transforms[link_name]);
+    }
+    visualization_->getLink(link_name)->setTrajectory(link_trajectory);
   }
 }
 
-void TrajectoryMonitorWidget::incomingDisplayTrajectory(const tesseract_msgs::Trajectory::ConstPtr& msg)
+void TrajectoryMonitorWidget::changedDisplayMode()
 {
-  visualize_trajectory_widget_->setDisplayTrajectory(msg);
+  if (display_mode_property_->getOptionInt() != 2)
+  {
+    if (display_->isEnabled() && displaying_trajectory_message_ && animating_path_)
+      return;
+
+    clearTrajectoryTrail();
+
+    if (trajectory_slider_panel_)
+      trajectory_slider_panel_->pauseButton(false);
+  }
+  else
+  {
+    if (trajectory_slider_panel_)
+      trajectory_slider_panel_->pauseButton(true);
+  }
+}
+
+void TrajectoryMonitorWidget::changedTrailStepSize()
+{
+  if (display_mode_property_->getOptionInt() == 2)
+  {
+    createTrajectoryTrail();
+    if (trajectory_slider_panel_)
+      trajectory_slider_panel_->update(static_cast<int>(num_trajectory_waypoints_));
+  }
+}
+
+void TrajectoryMonitorWidget::changedTrajectoryTopic()
+{
+  if(trajectory_topic_property_ && trajectory_topic_property_->getStdString() != "")
+  {
+  trajectory_topic_sub_.reset();
+  if (!trajectory_topic_property_->getStdString().empty())
+  {
+    trajectory_topic_sub_ = node_->create_subscription<tesseract_msgs::msg::Trajectory>(
+        trajectory_topic_property_->getStdString(), 5, std::bind(&TrajectoryMonitorWidget::incomingDisplayTrajectory, this, std::placeholders::_1));
+  }
+  }
+  else
+    CONSOLE_BRIDGE_logWarn("Tesseract trajectory topic is invalid");
+}
+
+void TrajectoryMonitorWidget::changedStateDisplayTime() {}
+
+void TrajectoryMonitorWidget::interruptCurrentDisplay()
+{
+  // update() starts a new trajectory as soon as it is available
+  // interrupting may cause the newly received trajectory to interrupt
+  // hence, only interrupt when current_state_ already advanced past first
+  if (current_state_ > 0)
+    animating_path_ = false;
+}
+
+float TrajectoryMonitorWidget::getStateDisplayTime()
+{
+  std::string tm = state_display_time_property_->getStdString();
+  if (tm == "REALTIME")
+    return -1.0;
+  else
+  {
+    boost::replace_all(tm, "s", "");
+    boost::trim(tm);
+    float t = 0.05f;
+    try
+    {
+      t = boost::lexical_cast<float>(tm);
+    }
+    catch (const boost::bad_lexical_cast& ex)
+    {
+      state_display_time_property_->setStdString("0.05 s");
+    }
+    return t;
+  }
+}
+
+void TrajectoryMonitorWidget::dropTrajectory() { drop_displaying_trajectory_ = true; }
+void TrajectoryMonitorWidget::onUpdate(float wall_dt)
+{
+  if (!tesseract_->isInitialized() || !visualization_)
+    return;
+
+  if (drop_displaying_trajectory_)
+  {
+    animating_path_ = false;
+    displaying_trajectory_message_.reset();
+    trajectory_slider_panel_->update(0);
+    drop_displaying_trajectory_ = false;
+  }
+
+  if (!animating_path_)
+  {  // finished last animation?
+
+    boost::mutex::scoped_lock lock(update_trajectory_message_);
+    // new trajectory available to display?
+    if (trajectory_message_to_display_ && !trajectory_message_to_display_->joint_trajectory.points.empty())
+    {
+      animating_path_ = true;
+
+      if (display_mode_property_->getOptionInt() == 2)
+        animating_path_ = false;
+
+      displaying_trajectory_message_ = trajectory_message_to_display_;
+      createTrajectoryTrail();
+      if (trajectory_slider_panel_)
+        trajectory_slider_panel_->update(static_cast<int>(num_trajectory_waypoints_));
+    }
+    else if (displaying_trajectory_message_)
+    {
+      if (display_mode_property_->getOptionInt() == 1)
+      {
+        animating_path_ = true;
+      }
+      else if (display_mode_property_->getOptionInt() == 0)
+      {
+        if (previous_display_mode_ != display_mode_property_->getOptionInt())
+        {
+          animating_path_ = true;
+        }
+        else
+        {
+          if (static_cast<unsigned>(trajectory_slider_panel_->getSliderPosition()) == (num_trajectory_waypoints_ - 1))
+            animating_path_ = false;
+          else
+            animating_path_ = true;
+        }
+      }
+      else
+      {
+        if (previous_display_mode_ != display_mode_property_->getOptionInt())
+        {
+          createTrajectoryTrail();
+          if (trajectory_slider_panel_)
+            trajectory_slider_panel_->update(static_cast<int>(num_trajectory_waypoints_));
+        }
+
+        animating_path_ = false;
+      }
+      previous_display_mode_ = display_mode_property_->getOptionInt();
+    }
+    trajectory_message_to_display_.reset();
+
+    if (animating_path_)
+    {
+      current_state_ = -1;
+      current_state_time_ = std::numeric_limits<float>::infinity();
+
+      for (const auto& link_name : tesseract_->getEnvironment()->getActiveLinkNames())
+        visualization_->getLink(link_name)->showTrajectoryWaypointOnly(0);
+
+      if (trajectory_slider_panel_)
+        trajectory_slider_panel_->setSliderPosition(0);
+    }
+  }
+
+  if (animating_path_)
+  {
+    float tm = getStateDisplayTime();
+    if (tm < 0.0)  // if we should use realtime
+    {
+      rclcpp::Duration d = displaying_trajectory_message_->joint_trajectory.points[static_cast<size_t>(current_state_) + 1]
+                            .time_from_start;
+      if (d.seconds() < 1e-6)
+        tm = 0;
+      else
+        tm = static_cast<float>(
+            (d - displaying_trajectory_message_->joint_trajectory.points[static_cast<size_t>(current_state_)]
+                     .time_from_start)
+                .seconds());
+    }
+
+    if (current_state_time_ > tm)
+    {
+      if (trajectory_slider_panel_ && trajectory_slider_panel_->isVisible() && trajectory_slider_panel_->isPaused())
+        current_state_ = trajectory_slider_panel_->getSliderPosition();
+      else
+        ++current_state_;
+
+      if (current_state_ < num_trajectory_waypoints_)
+      {
+        if (trajectory_slider_panel_)
+          trajectory_slider_panel_->setSliderPosition(current_state_);
+
+        for (const auto& link_name : tesseract_->getEnvironment()->getActiveLinkNames())
+          visualization_->getLink(link_name)->showTrajectoryWaypointOnly(current_state_);
+      }
+      else
+      {
+        animating_path_ = false;  // animation finished
+        if ((display_mode_property_->getOptionInt() != 1) && trajectory_slider_panel_)
+          trajectory_slider_panel_->pauseButton(true);
+      }
+      current_state_time_ = 0.0f;
+    }
+    current_state_time_ += wall_dt;
+  }
+}
+
+void TrajectoryMonitorWidget::incomingDisplayTrajectory(const tesseract_msgs::msg::Trajectory::ConstSharedPtr msg)
+{
+  // Error check
+  if (!tesseract_->isInitialized())
+  {
+    CONSOLE_BRIDGE_logError("trajectory_visualization", "No environment");
+    return;
+  }
+
+  if (visualization_ && !visualization_->isTrajectoryVisible())
+    visualization_->setTrajectoryVisible(true);
+
+  if (!msg->tesseract_state.id.empty() && msg->tesseract_state.id != tesseract_->getEnvironment()->getName())
+    CONSOLE_BRIDGE_logWarn("Received a trajectory to display for model '%s' but model '%s' "
+             "was expected",
+             msg->tesseract_state.id.c_str(),
+             tesseract_->getEnvironment()->getName().c_str());
+
+  if (!msg->joint_trajectory.points.empty())
+  {
+    bool joints_equal = true;
+    if (trajectory_message_to_display_)
+    {
+      if ((trajectory_message_to_display_->joint_trajectory.points.size() == msg->joint_trajectory.points.size()) &&
+          (trajectory_message_to_display_->joint_trajectory.joint_names.size() ==
+           msg->joint_trajectory.joint_names.size()))
+      {
+        for (unsigned i = 0; i < msg->joint_trajectory.points.size(); ++i)
+        {
+          for (unsigned j = 0; j < msg->joint_trajectory.joint_names.size(); ++j)
+          {
+            double delta = msg->joint_trajectory.points[i].positions[j] -
+                           trajectory_message_to_display_->joint_trajectory.points[i].positions[j];
+            joints_equal &= (std::abs(delta) < std::numeric_limits<double>::epsilon());
+          }
+        }
+      }
+      else
+      {
+        joints_equal = false;
+      }
+    }
+
+    trajectory_message_to_display_.reset();
+    if (!msg->joint_trajectory.points.empty() || !joints_equal)
+    {
+      boost::mutex::scoped_lock lock(update_trajectory_message_);
+      trajectory_message_to_display_.reset(new tesseract_msgs::msg::Trajectory(*msg));
+      if (interrupt_display_property_->getBool())
+        interruptCurrentDisplay();
+    }
+  }
+  else
+  {
+    trajectory_message_to_display_.reset();
+  }
+}
+
+void TrajectoryMonitorWidget::trajectorySliderPanelVisibilityChange(bool enable)
+{
+  if (!trajectory_slider_panel_)
+    return;
+
+  if (enable)
+    trajectory_slider_panel_->onEnable();
+  else
+    trajectory_slider_panel_->onDisable();
 }
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/src/render_tools/trajectory_monitor_widget.cpp
+++ b/tesseract_rviz/src/render_tools/trajectory_monitor_widget.cpp
@@ -36,9 +36,10 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <memory>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <rviz_common/display_context.hpp>
 #include <rviz_common/properties/bool_property.hpp>
@@ -52,6 +53,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <rviz_common/properties/string_property.hpp>
 #include <rviz_common/window_manager_interface.hpp>
 
+#include <tesseract_command_language/utils/utils.h>
 #include <tesseract_rosutils/utils.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
@@ -61,17 +63,13 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_rviz
 {
+const double SLIDER_RESOLUTION = 0.001;
+
 TrajectoryMonitorWidget::TrajectoryMonitorWidget(rviz_common::properties::Property* widget, rviz_common::Display* display)
   : widget_(widget)
   , display_(display)
-  , tesseract_(nullptr)
-  , visualization_(nullptr)
-  , animating_path_(false)
-  , drop_displaying_trajectory_(false)
-  , current_state_(-1)
-  , trajectory_slider_panel_(nullptr)
-  , trajectory_slider_dock_panel_(nullptr)
-  , cached_visible_(false)
+  , visualize_trajectory_widget_(std::make_shared<VisualizeTrajectoryWidget>(widget, display))  // should widget be
+                                                                                                // this?
 {
   main_property_ = new rviz_common::properties::Property(
       "Trajectory Monitor", "", "Monitor a joint state topic and update the visualization", widget_, nullptr, this);
@@ -84,441 +82,51 @@ TrajectoryMonitorWidget::TrajectoryMonitorWidget(rviz_common::properties::Proper
                                                           main_property_,
                                                           SLOT(changedTrajectoryTopic()),
                                                           this);
-
-  display_mode_property_ = new rviz_common::properties::EnumProperty(
-      "Display Mode", "Loop", "How to display the trajectoy.", main_property_, SLOT(changedDisplayMode()), this);
-  display_mode_property_->addOptionStd("Single", 0);
-  display_mode_property_->addOptionStd("Loop", 1);
-  display_mode_property_->addOptionStd("Trail", 2);
-
-  state_display_time_property_ = new rviz_common::properties::EditableEnumProperty("State Display Time",
-                                                                "0.05 s",
-                                                                "The amount of wall-time to wait in between displaying "
-                                                                "states along a received trajectory path",
-                                                                main_property_,
-                                                                SLOT(changedStateDisplayTime()),
-                                                                this);
-  state_display_time_property_->addOptionStd("REALTIME");
-  state_display_time_property_->addOptionStd("0.05 s");
-  state_display_time_property_->addOptionStd("0.1 s");
-  state_display_time_property_->addOptionStd("0.5 s");
-
-  trail_step_size_property_ = new rviz_common::properties::IntProperty("Trail Step Size",
-                                                    1,
-                                                    "Specifies the step size of the samples "
-                                                    "shown in the trajectory trail.",
-                                                    main_property_,
-                                                    SLOT(changedTrailStepSize()),
-                                                    this);
-  trail_step_size_property_->setMin(1);
-
-  interrupt_display_property_ = new rviz_common::properties::BoolProperty("Interrupt Display",
-                                                       false,
-                                                       "Immediately show newly planned trajectory, "
-                                                       "interrupting the currently displayed one.",
-                                                       main_property_);
 }
 
-TrajectoryMonitorWidget::~TrajectoryMonitorWidget()
-{
-  clearTrajectoryTrail();
-  trajectory_message_to_display_.reset();
-  displaying_trajectory_message_.reset();
+TrajectoryMonitorWidget::~TrajectoryMonitorWidget() {}
 
-  if (trajectory_slider_dock_panel_)
-    delete trajectory_slider_dock_panel_;
-}
-
-void TrajectoryMonitorWidget::onInitialize(VisualizationWidget::SharedPtr visualization,
-                                           tesseract::Tesseract::Ptr tesseract,
+void TrajectoryMonitorWidget::onInitialize(VisualizationWidget::Ptr visualization,
+                                           tesseract_environment::Environment::Ptr env,
                                            rviz_common::DisplayContext* context,
                                            rclcpp::Node::SharedPtr update_node)
 {
   // Save pointers for later use
-  visualization_ = std::move(visualization);
-  tesseract_ = std::move(tesseract);
   context_ = context;
   node_ = update_node;
 
-  previous_display_mode_ = display_mode_property_->getOptionInt();
-
-  auto rviz_ros_node = context->getRosNodeAbstraction();
-  trajectory_topic_property_->initialize(rviz_ros_node);
-
-  rviz_common::WindowManagerInterface* window_context = context_->getWindowManager();
-  if (window_context)
-  {
-    trajectory_slider_panel_ = new TrajectoryPanel(window_context->getParentWindow());
-    trajectory_slider_dock_panel_ =
-        window_context->addPane(display_->getName() + " - Slider", trajectory_slider_panel_);
-    trajectory_slider_dock_panel_->setIcon(display_->getIcon());
-    connect(trajectory_slider_dock_panel_,
-            SIGNAL(visibilityChanged(bool)),
-            this,
-            SLOT(trajectorySliderPanelVisibilityChange(bool)));
-    trajectory_slider_panel_->onInitialize();
-  }
+  visualize_trajectory_widget_->onInitialize(visualization, env, context);
 }
 
 void TrajectoryMonitorWidget::onEnable()
 {
-  visualization_->setTrajectoryVisible(cached_visible_);
-  changedTrajectoryTopic();  // load topic at startup if default used
+  visualize_trajectory_widget_->onEnable();
+  changedTrajectoryTopic();
 }
 
-void TrajectoryMonitorWidget::onDisable()
-{
-  cached_visible_ = visualization_->isTrajectoryVisible();
-  visualization_->setTrajectoryVisible(false);
-  displaying_trajectory_message_.reset();
-  animating_path_ = false;
+void TrajectoryMonitorWidget::onDisable() { visualize_trajectory_widget_->onDisable(); }
 
-  if (trajectory_slider_panel_)
-    trajectory_slider_panel_->onDisable();
-}
+void TrajectoryMonitorWidget::onUpdate(float wall_dt) { visualize_trajectory_widget_->onUpdate(wall_dt); }
 
-void TrajectoryMonitorWidget::onReset()
-{
-  clearTrajectoryTrail();
-  trajectory_message_to_display_.reset();
-  displaying_trajectory_message_.reset();
-  animating_path_ = false;
-}
+void TrajectoryMonitorWidget::onReset() { visualize_trajectory_widget_->onReset(); }
 
-void TrajectoryMonitorWidget::onNameChange(const QString& name)
-{
-  if (trajectory_slider_dock_panel_)
-    trajectory_slider_dock_panel_->setWindowTitle(name + " - Slider");
-}
-
-void TrajectoryMonitorWidget::clearTrajectoryTrail()
-{
-  for (auto& link_pair : visualization_->getLinks())
-    link_pair.second->clearTrajectory();
-}
-
-void TrajectoryMonitorWidget::createTrajectoryTrail()
-{
-  clearTrajectoryTrail();
-
-  tesseract_msgs::msg::Trajectory::SharedPtr t = trajectory_message_to_display_;
-  if (!t)
-    t = displaying_trajectory_message_;
-
-  if (!t)
-    return;
-
-  int stepsize = trail_step_size_property_->getInt();
-  // always include last trajectory point
-  int num_waypoints = static_cast<int>(t->joint_trajectory.points.size());
-  num_trajectory_waypoints_ =
-      static_cast<size_t>(std::ceil(static_cast<float>(num_waypoints + stepsize - 1) / static_cast<float>(stepsize)));
-  std::vector<tesseract_environment::EnvState::Ptr> states_data;
-  states_data.reserve(num_trajectory_waypoints_);
-  for (std::size_t i = 0; i < num_trajectory_waypoints_; i++)
-  {
-    unsigned waypoint_i = static_cast<unsigned>(std::min(
-        i * static_cast<size_t>(stepsize), static_cast<size_t>(num_waypoints - 1)));  // limit to last trajectory point
-
-    std::unordered_map<std::string, double> joints;
-    for (unsigned j = 0; j < t->joint_trajectory.joint_names.size(); ++j)
-    {
-      joints[t->joint_trajectory.joint_names[j]] = t->joint_trajectory.points[waypoint_i].positions[j];
-    }
-
-    states_data.push_back(tesseract_->getEnvironment()->getState(joints));
-  }
-
-  // If current state is not visible must set trajectory for all links for a single state so static
-  // objects will be visible
-  for (const auto& tf : states_data[0]->link_transforms)
-  {
-    LinkWidget* lw = visualization_->getLink(tf.first);
-    lw->clearTrajectory();
-
-    if (!visualization_->isCurrentStateVisible())
-      lw->setTrajectory({ tf.second });
-  }
-
-  // Set Trajectory for active links
-  for (const auto& link_name : tesseract_->getEnvironment()->getActiveLinkNames())
-  {
-    std::vector<Eigen::Isometry3d> link_trajectory;
-    link_trajectory.reserve(states_data.size());
-    for (auto& state : states_data)
-    {
-      link_trajectory.push_back(state->link_transforms[link_name]);
-    }
-    visualization_->getLink(link_name)->setTrajectory(link_trajectory);
-  }
-}
-
-void TrajectoryMonitorWidget::changedDisplayMode()
-{
-  if (display_mode_property_->getOptionInt() != 2)
-  {
-    if (display_->isEnabled() && displaying_trajectory_message_ && animating_path_)
-      return;
-
-    clearTrajectoryTrail();
-
-    if (trajectory_slider_panel_)
-      trajectory_slider_panel_->pauseButton(false);
-  }
-  else
-  {
-    if (trajectory_slider_panel_)
-      trajectory_slider_panel_->pauseButton(true);
-  }
-}
-
-void TrajectoryMonitorWidget::changedTrailStepSize()
-{
-  if (display_mode_property_->getOptionInt() == 2)
-  {
-    createTrajectoryTrail();
-    if (trajectory_slider_panel_)
-      trajectory_slider_panel_->update(static_cast<int>(num_trajectory_waypoints_));
-  }
-}
+void TrajectoryMonitorWidget::onNameChange(const QString& name) { visualize_trajectory_widget_->onNameChange(name); }
 
 void TrajectoryMonitorWidget::changedTrajectoryTopic()
 {
   if(trajectory_topic_property_ && trajectory_topic_property_->getStdString() != "")
   {
-  trajectory_topic_sub_.reset();
-  if (!trajectory_topic_property_->getStdString().empty())
-  {
+    trajectory_topic_sub_.reset();
     trajectory_topic_sub_ = node_->create_subscription<tesseract_msgs::msg::Trajectory>(
         trajectory_topic_property_->getStdString(), 5, std::bind(&TrajectoryMonitorWidget::incomingDisplayTrajectory, this, std::placeholders::_1));
-  }
   }
   else
     CONSOLE_BRIDGE_logWarn("Tesseract trajectory topic is invalid");
 }
 
-void TrajectoryMonitorWidget::changedStateDisplayTime() {}
-
-void TrajectoryMonitorWidget::interruptCurrentDisplay()
+void TrajectoryMonitorWidget::incomingDisplayTrajectory(tesseract_msgs::msg::Trajectory::ConstSharedPtr msg)
 {
-  // update() starts a new trajectory as soon as it is available
-  // interrupting may cause the newly received trajectory to interrupt
-  // hence, only interrupt when current_state_ already advanced past first
-  if (current_state_ > 0)
-    animating_path_ = false;
-}
-
-float TrajectoryMonitorWidget::getStateDisplayTime()
-{
-  std::string tm = state_display_time_property_->getStdString();
-  if (tm == "REALTIME")
-    return -1.0;
-  else
-  {
-    boost::replace_all(tm, "s", "");
-    boost::trim(tm);
-    float t = 0.05f;
-    try
-    {
-      t = boost::lexical_cast<float>(tm);
-    }
-    catch (const boost::bad_lexical_cast& ex)
-    {
-      state_display_time_property_->setStdString("0.05 s");
-    }
-    return t;
-  }
-}
-
-void TrajectoryMonitorWidget::dropTrajectory() { drop_displaying_trajectory_ = true; }
-void TrajectoryMonitorWidget::onUpdate(float wall_dt)
-{
-  if (!tesseract_->isInitialized() || !visualization_)
-    return;
-
-  if (drop_displaying_trajectory_)
-  {
-    animating_path_ = false;
-    displaying_trajectory_message_.reset();
-    trajectory_slider_panel_->update(0);
-    drop_displaying_trajectory_ = false;
-  }
-
-  if (!animating_path_)
-  {  // finished last animation?
-
-    boost::mutex::scoped_lock lock(update_trajectory_message_);
-    // new trajectory available to display?
-    if (trajectory_message_to_display_ && !trajectory_message_to_display_->joint_trajectory.points.empty())
-    {
-      animating_path_ = true;
-
-      if (display_mode_property_->getOptionInt() == 2)
-        animating_path_ = false;
-
-      displaying_trajectory_message_ = trajectory_message_to_display_;
-      createTrajectoryTrail();
-      if (trajectory_slider_panel_)
-        trajectory_slider_panel_->update(static_cast<int>(num_trajectory_waypoints_));
-    }
-    else if (displaying_trajectory_message_)
-    {
-      if (display_mode_property_->getOptionInt() == 1)
-      {
-        animating_path_ = true;
-      }
-      else if (display_mode_property_->getOptionInt() == 0)
-      {
-        if (previous_display_mode_ != display_mode_property_->getOptionInt())
-        {
-          animating_path_ = true;
-        }
-        else
-        {
-          if (static_cast<unsigned>(trajectory_slider_panel_->getSliderPosition()) == (num_trajectory_waypoints_ - 1))
-            animating_path_ = false;
-          else
-            animating_path_ = true;
-        }
-      }
-      else
-      {
-        if (previous_display_mode_ != display_mode_property_->getOptionInt())
-        {
-          createTrajectoryTrail();
-          if (trajectory_slider_panel_)
-            trajectory_slider_panel_->update(static_cast<int>(num_trajectory_waypoints_));
-        }
-
-        animating_path_ = false;
-      }
-      previous_display_mode_ = display_mode_property_->getOptionInt();
-    }
-    trajectory_message_to_display_.reset();
-
-    if (animating_path_)
-    {
-      current_state_ = -1;
-      current_state_time_ = std::numeric_limits<float>::infinity();
-
-      for (const auto& link_name : tesseract_->getEnvironment()->getActiveLinkNames())
-        visualization_->getLink(link_name)->showTrajectoryWaypointOnly(0);
-
-      if (trajectory_slider_panel_)
-        trajectory_slider_panel_->setSliderPosition(0);
-    }
-  }
-
-  if (animating_path_)
-  {
-    float tm = getStateDisplayTime();
-    if (tm < 0.0)  // if we should use realtime
-    {
-      rclcpp::Duration d = displaying_trajectory_message_->joint_trajectory.points[static_cast<size_t>(current_state_) + 1]
-                            .time_from_start;
-      if (d.seconds() < 1e-6)
-        tm = 0;
-      else
-        tm = static_cast<float>(
-            (d - displaying_trajectory_message_->joint_trajectory.points[static_cast<size_t>(current_state_)]
-                     .time_from_start)
-                .seconds());
-    }
-
-    if (current_state_time_ > tm)
-    {
-      if (trajectory_slider_panel_ && trajectory_slider_panel_->isVisible() && trajectory_slider_panel_->isPaused())
-        current_state_ = trajectory_slider_panel_->getSliderPosition();
-      else
-        ++current_state_;
-
-      if (current_state_ < num_trajectory_waypoints_)
-      {
-        if (trajectory_slider_panel_)
-          trajectory_slider_panel_->setSliderPosition(current_state_);
-
-        for (const auto& link_name : tesseract_->getEnvironment()->getActiveLinkNames())
-          visualization_->getLink(link_name)->showTrajectoryWaypointOnly(current_state_);
-      }
-      else
-      {
-        animating_path_ = false;  // animation finished
-        if ((display_mode_property_->getOptionInt() != 1) && trajectory_slider_panel_)
-          trajectory_slider_panel_->pauseButton(true);
-      }
-      current_state_time_ = 0.0f;
-    }
-    current_state_time_ += wall_dt;
-  }
-}
-
-void TrajectoryMonitorWidget::incomingDisplayTrajectory(const tesseract_msgs::msg::Trajectory::ConstSharedPtr msg)
-{
-  // Error check
-  if (!tesseract_->isInitialized())
-  {
-    CONSOLE_BRIDGE_logError("trajectory_visualization", "No environment");
-    return;
-  }
-
-  if (visualization_ && !visualization_->isTrajectoryVisible())
-    visualization_->setTrajectoryVisible(true);
-
-  if (!msg->tesseract_state.id.empty() && msg->tesseract_state.id != tesseract_->getEnvironment()->getName())
-    CONSOLE_BRIDGE_logWarn("Received a trajectory to display for model '%s' but model '%s' "
-             "was expected",
-             msg->tesseract_state.id.c_str(),
-             tesseract_->getEnvironment()->getName().c_str());
-
-  if (!msg->joint_trajectory.points.empty())
-  {
-    bool joints_equal = true;
-    if (trajectory_message_to_display_)
-    {
-      if ((trajectory_message_to_display_->joint_trajectory.points.size() == msg->joint_trajectory.points.size()) &&
-          (trajectory_message_to_display_->joint_trajectory.joint_names.size() ==
-           msg->joint_trajectory.joint_names.size()))
-      {
-        for (unsigned i = 0; i < msg->joint_trajectory.points.size(); ++i)
-        {
-          for (unsigned j = 0; j < msg->joint_trajectory.joint_names.size(); ++j)
-          {
-            double delta = msg->joint_trajectory.points[i].positions[j] -
-                           trajectory_message_to_display_->joint_trajectory.points[i].positions[j];
-            joints_equal &= (std::abs(delta) < std::numeric_limits<double>::epsilon());
-          }
-        }
-      }
-      else
-      {
-        joints_equal = false;
-      }
-    }
-
-    trajectory_message_to_display_.reset();
-    if (!msg->joint_trajectory.points.empty() || !joints_equal)
-    {
-      boost::mutex::scoped_lock lock(update_trajectory_message_);
-      trajectory_message_to_display_.reset(new tesseract_msgs::msg::Trajectory(*msg));
-      if (interrupt_display_property_->getBool())
-        interruptCurrentDisplay();
-    }
-  }
-  else
-  {
-    trajectory_message_to_display_.reset();
-  }
-}
-
-void TrajectoryMonitorWidget::trajectorySliderPanelVisibilityChange(bool enable)
-{
-  if (!trajectory_slider_panel_)
-    return;
-
-  if (enable)
-    trajectory_slider_panel_->onEnable();
-  else
-    trajectory_slider_panel_->onDisable();
+  visualize_trajectory_widget_->setDisplayTrajectory(*msg);
 }
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/src/render_tools/visualization_widget.cpp
+++ b/tesseract_rviz/src/render_tools/visualization_widget.cpp
@@ -121,9 +121,9 @@ VisualizationWidget::~VisualizationWidget()
 {
   clear();
 
-  scene_manager_->destroySceneNode(root_visual_node_->getName());
-  scene_manager_->destroySceneNode(root_collision_node_->getName());
-  scene_manager_->destroySceneNode(root_other_node_->getName());
+  scene_manager_->destroySceneNode(root_visual_node_);
+  scene_manager_->destroySceneNode(root_collision_node_);
+  scene_manager_->destroySceneNode(root_other_node_);
   delete link_factory_;
   delete link_tree_;
 }

--- a/tesseract_rviz/src/render_tools/visualization_widget.cpp
+++ b/tesseract_rviz/src/render_tools/visualization_widget.cpp
@@ -30,7 +30,7 @@
 #include "tesseract_rviz/render_tools/visualization_widget.h"
 #include "tesseract_rviz/render_tools/joint_widget.h"
 #include "tesseract_rviz/render_tools/link_widget.h"
-#include "tesseract_scene_graph/allowed_collision_matrix.h"
+#include "tesseract_common/allowed_collision_matrix.h"
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
@@ -51,6 +51,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <OgreSceneNode.h>
 
 #include <console_bridge/console.h>
+#include <ament_index_cpp/get_package_share_directory.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/conversions.h>
@@ -59,9 +60,10 @@ namespace tesseract_rviz
 {
 VisualizationWidget::VisualizationWidget(Ogre::SceneNode* root_node,
                                          rviz_common::DisplayContext* context,
-                                         const std::string& name,
+                                         std::string name,
                                          rviz_common::properties::Property* parent_property)
   : scene_manager_(context->getSceneManager())
+  , scene_graph_(std::make_shared<tesseract_scene_graph::SceneGraph>())
   , visible_(true)
   , visual_visible_(true)
   , collision_visible_(false)
@@ -70,11 +72,16 @@ VisualizationWidget::VisualizationWidget(Ogre::SceneNode* root_node,
   , end_state_visible_(false)
   , trajectory_visible_(false)
   , context_(context)
+  , link_tree_(nullptr)
   , doing_set_checkbox_(false)
-  , env_loaded_(false)
   , inChangedEnableAllLinks(false)
-  , name_(name)
+  , name_(std::move(name))
 {
+  // Add tesseract resources to ogre
+  std::string tesseract_rviz_path = ament_index_cpp::get_package_share_directory("tesseract_rviz");
+  Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
+      tesseract_rviz_path + "/ogre_media/models", "FileSystem", "tesseract_rviz");
+
   root_visual_node_ = root_node->createChildSceneNode();
   root_collision_node_ = root_node->createChildSceneNode();
   root_other_node_ = root_node->createChildSceneNode();
@@ -118,6 +125,7 @@ VisualizationWidget::~VisualizationWidget()
   scene_manager_->destroySceneNode(root_collision_node_->getName());
   scene_manager_->destroySceneNode(root_other_node_->getName());
   delete link_factory_;
+  delete link_tree_;
 }
 
 void VisualizationWidget::setLinkFactory(LinkFactory* link_factory)
@@ -228,14 +236,20 @@ void VisualizationWidget::clear()
   root_visual_node_->removeAndDestroyAllChildren();
   root_collision_node_->removeAndDestroyAllChildren();
   root_other_node_->removeAndDestroyAllChildren();
+  scene_graph_->clear();
+
+  root_link_ = nullptr;
+  link_tree_->hide();
 }
 
-LinkWidget* VisualizationWidget::LinkFactory::createLink(VisualizationWidget* robot,
+bool VisualizationWidget::isInitialized() const { return initialized_; }
+
+LinkWidget* VisualizationWidget::LinkFactory::createLink(VisualizationWidget* env,
                                                          const tesseract_scene_graph::Link& link,
                                                          bool visual,
                                                          bool collision)
 {
-  return new LinkWidget(robot, link, visual, collision);
+  return new LinkWidget(env, link, visual, collision);
 }
 
 JointWidget* VisualizationWidget::LinkFactory::createJoint(VisualizationWidget* robot,
@@ -244,14 +258,10 @@ JointWidget* VisualizationWidget::LinkFactory::createJoint(VisualizationWidget* 
   return new JointWidget(robot, joint);
 }
 
-void VisualizationWidget::load(const tesseract_scene_graph::SceneGraph::ConstPtr& scene_graph,
-                               bool visual,
-                               bool collision,
-                               bool show_active,
-                               bool show_static)
+void VisualizationWidget::initialize(bool visual, bool collision, bool show_active, bool show_static)
 {
   link_tree_->hide();  // hide until loaded
-  env_loaded_ = false;
+  initialized_ = false;
   load_visual_ = visual;
   load_collision_ = collision;
   load_active_ = show_active;
@@ -263,40 +273,11 @@ void VisualizationWidget::load(const tesseract_scene_graph::SceneGraph::ConstPtr
   // Populate the list of active links
   //  tesseract::tesseract_ros::getActiveLinkNamesRecursive(active_links_, urdf->getRoot(), false);
 
-  // the root link is discovered below.  Set to nullptr until found.
-  root_link_ = nullptr;
-
-  // Create properties for each link.
-  // Properties are not added to display until changedLinkTreeStyle() is called
-  // (below).
-  {
-    std::vector<tesseract_scene_graph::Link::ConstPtr> links = scene_graph->getLinks();
-    for (const tesseract_scene_graph::Link::ConstPtr& tlink : links)
-      addLink(*tlink);
-
-    root_link_ = links_[scene_graph->getRoot()];
-  }
-
-  // Create properties for each joint.
-  // Properties are not added to display until changedLinkTreeStyle() is called
-  // (below).
-  {
-    std::vector<tesseract_scene_graph::Joint::ConstPtr> joints = scene_graph->getJoints();
-    for (const tesseract_scene_graph::Joint::ConstPtr& tjoint : joints)
-      addJoint(*tjoint);
-  }
-
-  // Add allowed collision matrix
-  for (const auto& acm_pair : scene_graph->getAllowedCollisionMatrix()->getAllAllowedCollisions())
-    addAllowedCollision(acm_pair.first.first, acm_pair.first.second, acm_pair.second);
-
-  // environment is now loaded
-  env_loaded_ = true;
+  // Show Tree
   link_tree_->show();
 
   // set the link tree style and add link/joint properties to rviz pane.
   setLinkTreeStyle(LinkTreeStyle(link_tree_style_->getOptionInt()));
-  changedLinkTreeStyle();
 
   // at startup the link tree is collapsed since it is large and not often
   // needed.
@@ -304,11 +285,108 @@ void VisualizationWidget::load(const tesseract_scene_graph::SceneGraph::ConstPtr
 
   setVisualVisible(isVisualVisible());
   setCollisionVisible(isCollisionVisible());
+
+  initialized_ = true;
 }
 
-bool VisualizationWidget::addLink(const tesseract_scene_graph::Link& link)
+bool VisualizationWidget::addSceneGraph(const tesseract_scene_graph::SceneGraph& scene_graph, const std::string& prefix)
 {
-  if (links_.find(link.getName()) != links_.end())
+  unparentLinkProperties();
+
+  // Create properties for each link.
+  // Properties are not added to display until changedLinkTreeStyle() is called
+  // (below).
+  {
+    bool is_scene_empty = scene_graph_->isEmpty();
+    std::vector<tesseract_scene_graph::Link::ConstPtr> links = scene_graph.getLinks();
+    for (const tesseract_scene_graph::Link::ConstPtr& tlink : links)
+    {
+      if (prefix.empty())
+        addLink(tlink->clone());
+      else
+        addLink(tlink->clone(prefix));
+    }
+
+    if (is_scene_empty)
+    {
+      scene_graph_->setRoot(scene_graph_->getRoot());
+      root_link_ = links_[scene_graph_->getRoot()];
+    }
+  }
+
+  // Create properties for each joint.
+  // Properties are not added to display until changedLinkTreeStyle() is called
+  // (below).
+  {
+    std::vector<tesseract_scene_graph::Joint::ConstPtr> joints = scene_graph.getJoints();
+    for (const tesseract_scene_graph::Joint::ConstPtr& tjoint : joints)
+    {
+      if (prefix.empty())
+        addJoint(tjoint->clone());
+      else
+        addJoint(tjoint->clone(prefix));
+    }
+  }
+
+  // Add allowed collision matrix
+  for (const auto& acm_pair : scene_graph.getAllowedCollisionMatrix()->getAllAllowedCollisions())
+    addAllowedCollision(acm_pair.first.first, acm_pair.first.second, acm_pair.second);
+
+  return true;
+}
+
+bool VisualizationWidget::addSceneGraph(const tesseract_scene_graph::SceneGraph& scene_graph,
+                                        const tesseract_scene_graph::Joint& joint,
+                                        const std::string& prefix)
+{
+  unparentLinkProperties();
+
+  // Create properties for each link.
+  // Properties are not added to display until changedLinkTreeStyle() is called
+  // (below).
+  {
+    assert(!scene_graph_->isEmpty());
+    std::vector<tesseract_scene_graph::Link::ConstPtr> links = scene_graph.getLinks();
+    for (const tesseract_scene_graph::Link::ConstPtr& tlink : links)
+    {
+      if (prefix.empty())
+        addLink(tlink->clone());
+      else
+        addLink(tlink->clone(prefix));
+    }
+  }
+
+  // Create properties for each joint.
+  // Properties are not added to display until changedLinkTreeStyle() is called
+  // (below).
+  {
+    // Add connecting joint
+    addJoint(joint);
+
+    // Add all other joints
+    std::vector<tesseract_scene_graph::Joint::ConstPtr> joints = scene_graph.getJoints();
+    for (const tesseract_scene_graph::Joint::ConstPtr& tjoint : joints)
+    {
+      if (prefix.empty())
+        addJoint(tjoint->clone());
+      else
+        addJoint(tjoint->clone(prefix));
+    }
+  }
+
+  // Add allowed collision matrix
+  for (const auto& acm_pair : scene_graph.getAllowedCollisionMatrix()->getAllAllowedCollisions())
+    addAllowedCollision(acm_pair.first.first, acm_pair.first.second, acm_pair.second);
+
+  return true;
+}
+
+bool VisualizationWidget::addLink(const tesseract_scene_graph::Link& link, bool replace_allowed)
+{
+  unparentLinkProperties();
+
+  bool link_exists = (links_.find(link.getName()) != links_.end());
+  if (link_exists && !replace_allowed)
   {
     CONSOLE_BRIDGE_logWarn("Tried to add link (%s) with same name as an existing link.", link.getName().c_str());
     return false;
@@ -319,20 +397,31 @@ bool VisualizationWidget::addLink(const tesseract_scene_graph::Link& link)
   if ((!load_active_ && is_active) || (!load_static_ && !is_active))
     show_geom = false;
 
+  // Add or replace link
+  if (!scene_graph_->addLink(link, link_exists))
+    return false;
+
+  // Remove current link widget if exists
+  if (link_exists)
+  {
+    LinkWidget* current_link = links_[link.getName()];
+    links_.erase(link.getName());
+    current_link->setParentProperty(nullptr);
+    delete current_link;
+  }
+
   LinkWidget* tlink = link_factory_->createLink(this, link, load_visual_ & show_geom, load_collision_ & show_geom);
-
-  links_[link.getName()] = tlink;
-
   tlink->setAlpha(alpha_);
   tlink->updateVisibility();
 
-  changedLinkTreeStyle();
+  links_[link.getName()] = tlink;
 
   return true;
 }
 
 bool VisualizationWidget::removeLink(const std::string& name)
 {
+  unparentLinkProperties();
   auto it = links_.find(name);
   if (it == links_.end())
   {
@@ -340,31 +429,113 @@ bool VisualizationWidget::removeLink(const std::string& name)
     return false;
   }
 
+  std::vector<tesseract_scene_graph::Joint::ConstPtr> joints = scene_graph_->getInboundJoints(name);
+  assert(joints.size() <= 1);
+
+  // get child link names to remove
+  std::vector<std::string> child_link_names = scene_graph_->getLinkChildrenNames(name);
+
   LinkWidget* link = it->second;
   link->setParentProperty(nullptr);
   delete link;
   links_.erase(name);
+  scene_graph_->removeLink(name);
 
-  changedLinkTreeStyle();
+  for (const auto& link_name : child_link_names)
+  {
+    auto it2 = links_.find(link_name);
+    LinkWidget* link = it2->second;
+    link->setParentProperty(nullptr);
+    delete link;
+    links_.erase(link_name);
+
+    std::vector<tesseract_scene_graph::Joint::ConstPtr> joints = scene_graph_->getInboundJoints(link_name);
+    if (joints.size() == 1)
+    {
+      auto it3 = joints_.find(name);
+      if (it3 != joints_.end())
+      {
+        JointWidget* joint = it3->second;
+        joint->setParentProperty(nullptr);
+        delete joint;
+        joints_.erase(joints[0]->getName());
+      }
+    }
+    scene_graph_->removeLink(link_name);
+  }
 
   return true;
 }
 
-bool VisualizationWidget::addJoint(const tesseract_scene_graph::Joint& joint)
+bool VisualizationWidget::moveLink(const tesseract_scene_graph::Joint& joint)
 {
-  if (joints_.find(joint.getName()) != joints_.end())
+  unparentLinkProperties();
+
+  std::vector<tesseract_scene_graph::Joint::ConstPtr> joints = scene_graph_->getInboundJoints(joint.child_link_name);
+  assert(joints.size() == 1);
+
+  auto it = joints_.find(joints[0]->getName());
+  if (it != joints_.end())
+  {
+    JointWidget* joint = it->second;
+    joint->setParentProperty(nullptr);
+    delete joint;
+    joints_.erase(joints[0]->getName());
+  }
+
+  if (!addJoint(joint.clone()))
+    return false;
+
+  scene_graph_->removeJoint(joints[0]->getName());
+
+  return true;
+}
+
+bool VisualizationWidget::addJoint(const tesseract_scene_graph::Joint& joint, bool replace)
+{
+  unparentLinkProperties();
+
+  bool joint_exists = (joints_.find(joint.getName()) != joints_.end());
+  if (joint_exists && !replace)
   {
     CONSOLE_BRIDGE_logWarn("Tried to add joint (%s) with same name as an existing joint.", joint.getName().c_str());
     return false;
   }
 
+  if (!joint_exists && replace)
+  {
+    CONSOLE_BRIDGE_logWarn("Tried to replace joint (%s) which does not exist.", joint.getName().c_str());
+    return false;
+  }
+
+  if (joint_exists)
+  {
+    // Add link to scene_graph
+    if (!scene_graph_->removeJoint(joint.getName()))
+      return false;
+
+    // Add link to scene_graph
+    if (!scene_graph_->addJoint(joint.clone()))
+      return false;
+
+    // Remove current joint widget
+    JointWidget* current_joint = joints_[joint.getName()];
+    current_joint->setParentProperty(nullptr);
+    delete current_joint;
+    joints_.erase(joint.getName());
+  }
+  else
+  {
+    // Add link to scene_graph
+    if (!scene_graph_->addJoint(joint.clone()))
+      return false;
+  }
+
+  // Add new joint widget
   JointWidget* tjoint = link_factory_->createJoint(this, joint);
-
-  joints_[joint.getName()] = tjoint;
-
   tjoint->setAlpha(alpha_);
 
-  changedLinkTreeStyle();
+  joints_[joint.getName()] = tjoint;
 
   return true;
 }
@@ -379,17 +550,13 @@ bool VisualizationWidget::removeJoint(const std::string& name)
   }
 
   JointWidget* joint = it->second;
-  joint->setParentProperty(nullptr);
-  delete joint;
-  joints_.erase(name);
-
-  changedLinkTreeStyle();
-
-  return true;
+  return removeLink(joint->getChildLinkName());
 }
 
 bool VisualizationWidget::moveJoint(const std::string& joint_name, const std::string& parent_link)
 {
+  unparentLinkProperties();
+
   auto it = joints_.find(joint_name);
   if (it == joints_.end())
   {
@@ -400,7 +567,17 @@ bool VisualizationWidget::moveJoint(const std::string& joint_name, const std::st
   JointWidget* joint = it->second;
   joint->setParentLinkName(parent_link);
 
-  changedLinkTreeStyle();
+  // Move joint in scene_graph
+  tesseract_scene_graph::Joint::ConstPtr cj = scene_graph_->getJoint(joint_name);
+  tesseract_scene_graph::Joint nj = cj->clone(joint_name);
+  nj.parent_link_name = parent_link;
+  std::vector<tesseract_scene_graph::Joint::ConstPtr> joints = scene_graph_->getInboundJoints(cj->child_link_name);
+  assert(joints.size() == 1);
+  if (!scene_graph_->removeJoint(joints[0]->getName()))
+    return false;
+
+  if (!scene_graph_->addJoint(std::move(nj)))
+    return false;
 
   return true;
 }
@@ -421,6 +598,8 @@ bool VisualizationWidget::changeJointOrigin(const std::string& name, const Eigen
   Ogre::Quaternion quat;
   toOgre(pos, quat, new_origin);
   joint->setTransforms(pos, quat);
+
+  scene_graph_->changeJointOrigin(name, new_origin);
   return true;
 }
 
@@ -428,6 +607,8 @@ void VisualizationWidget::addAllowedCollision(const std::string& link_name1,
                                               const std::string& link_name2,
                                               const std::string& reason)
 {
+  unparentLinkProperties();
+
   auto it1 = links_.find(link_name1);
   if (it1 == links_.end())
   {
@@ -448,11 +629,14 @@ void VisualizationWidget::addAllowedCollision(const std::string& link_name1,
   LinkWidget* link2 = it2->second;
   link2->addAllowedCollision(link_name1, reason);
 
-  changedLinkTreeStyle();
+  // Add to scene graph
+  scene_graph_->addAllowedCollision(link_name1, link_name2, reason);
 }
 
 void VisualizationWidget::removeAllowedCollision(const std::string& link_name1, const std::string& link_name2)
 {
+  unparentLinkProperties();
+
   auto it1 = links_.find(link_name1);
   if (it1 == links_.end())
   {
@@ -473,11 +657,14 @@ void VisualizationWidget::removeAllowedCollision(const std::string& link_name1, 
   LinkWidget* link2 = it2->second;
   link2->removeAllowedCollision(link_name1);
 
-  changedLinkTreeStyle();
+  // Remove from scene graph
+  scene_graph_->removeAllowedCollision(link_name1, link_name2);
 }
 
 void VisualizationWidget::removeAllowedCollision(const std::string& link_name)
 {
+  unparentLinkProperties();
+
   auto it = links_.find(link_name);
   if (it == links_.end())
   {
@@ -492,6 +679,9 @@ void VisualizationWidget::removeAllowedCollision(const std::string& link_name)
     LinkWidget* link = link_pair.second;
     link->removeAllowedCollision(link_name);
   }
+
+  // Remove from scene graph
+  scene_graph_->removeAllowedCollision(link_name);
 }
 
 void VisualizationWidget::setLinkCollisionEnabled(const std::string& name, bool enabled)
@@ -505,6 +695,21 @@ void VisualizationWidget::setLinkCollisionEnabled(const std::string& name, bool 
 
   LinkWidget* link = it->second;
   link->setCollisionEnabled(enabled);
+  scene_graph_->setLinkCollisionEnabled(name, enabled);
+}
+
+void VisualizationWidget::setLinkVisibleEnabled(const std::string& name, bool enabled)
+{
+  auto it = links_.find(name);
+  if (it == links_.end())
+  {
+    CONSOLE_BRIDGE_logWarn("Tried to change link (%s) collision enabled, which does not exist", name.c_str());
+    return;
+  }
+
+  LinkWidget* link = it->second;
+  link->setVisibleEnabled(enabled);
+  scene_graph_->setLinkCollisionEnabled(name, enabled);
 }
 
 void VisualizationWidget::unparentLinkProperties()
@@ -597,7 +802,7 @@ void VisualizationWidget::changedEnableAllLinks()
   inChangedEnableAllLinks = false;
 }
 
-void VisualizationWidget::setEnableAllLinksCheckbox(QVariant val)
+void VisualizationWidget::setEnableAllLinksCheckbox(const QVariant& val)
 {
   // doing_set_checkbox_ prevents changedEnableAllLinks from turning all
   // links off when we modify the enable_all_links_ property.
@@ -676,10 +881,7 @@ JointWidget* VisualizationWidget::findChildJoint(LinkWidget* link)
 // insert properties into link_tree_ according to style
 void VisualizationWidget::changedLinkTreeStyle()
 {
-  if (!env_loaded_)
-    return;
-
-  LinkTreeStyle style = LinkTreeStyle(link_tree_style_->getOptionInt());
+  auto style = LinkTreeStyle(link_tree_style_->getOptionInt());
 
   unparentLinkProperties();
 
@@ -757,8 +959,8 @@ void VisualizationWidget::changedLinkTreeStyle()
     case STYLE_JOINT_LIST:
     {
       useDetailProperty(false);
-      M_NameToJoint::iterator joint_it = joints_.begin();
-      M_NameToJoint::iterator joint_end = joints_.end();
+      auto joint_it = joints_.begin();
+      auto joint_end = joints_.end();
       for (; joint_it != joint_end; ++joint_it)
       {
         joint_it->second->setParentProperty(link_tree_);
@@ -814,6 +1016,9 @@ void VisualizationWidget::changedLinkTreeStyle()
       break;
   }
 
+  if (link_tree_->getHidden())
+    link_tree_->show();
+
   expand_link_details_->setValue(false);
   expand_joint_details_->setValue(false);
   expand_tree_->setValue(false);
@@ -822,7 +1027,7 @@ void VisualizationWidget::changedLinkTreeStyle()
 
 LinkWidget* VisualizationWidget::getLink(const std::string& name)
 {
-  M_NameToLink::iterator it = links_.find(name);
+  auto it = links_.find(name);
   if (it == links_.end())
   {
     CONSOLE_BRIDGE_logWarn("Link [%s] does not exist", name.c_str());
@@ -834,7 +1039,7 @@ LinkWidget* VisualizationWidget::getLink(const std::string& name)
 
 JointWidget* VisualizationWidget::getJoint(const std::string& name)
 {
-  M_NameToJoint::iterator it = joints_.find(name);
+  auto it = joints_.find(name);
   if (it == joints_.end())
   {
     CONSOLE_BRIDGE_logWarn("Joint [%s] does not exist", name.c_str());
@@ -846,7 +1051,7 @@ JointWidget* VisualizationWidget::getJoint(const std::string& name)
 
 void VisualizationWidget::calculateJointCheckboxes()
 {
-  if (inChangedEnableAllLinks || !env_loaded_)
+  if (inChangedEnableAllLinks)
     return;
 
   int links_with_geom_checked = 0;
@@ -896,6 +1101,8 @@ void VisualizationWidget::calculateJointCheckboxes()
   }
 }
 
+void VisualizationWidget::update() { changedLinkTreeStyle(); }
+
 void VisualizationWidget::update(const TransformMap& transforms)
 {
   for (auto& link_pair : links_)
@@ -906,44 +1113,9 @@ void VisualizationWidget::update(const TransformMap& transforms)
     auto it = transforms.find(link->getName());
     if (it != transforms.end())
     {
-      //      // Check if visual_orientation, visual_position, collision_orientation,
-      //      // and collision_position are NaN.
-      //      if (visual_orientation.isNaN())
-      //      {
-      //        ROS_ERROR_THROTTLE(1.0,
-      //                           "visual orientation of %s contains NaNs. "
-      //                           "Skipping render as long as the orientation is "
-      //                           "invalid.",
-      //                           link->getName().c_str());
-      //        continue;
-      //      }
-      //      if (visual_position.isNaN())
-      //      {
-      //        ROS_ERROR_THROTTLE(1.0,
-      //                           "visual position of %s contains NaNs. Skipping "
-      //                           "render as long as the position is invalid.",
-      //                           link->getName().c_str());
-      //        continue;
-      //      }
-      //      if (collision_orientation.isNaN())
-      //      {
-      //        ROS_ERROR_THROTTLE(1.0,
-      //                           "collision orientation of %s contains NaNs. "
-      //                           "Skipping render as long as the orientation is "
-      //                           "invalid.",
-      //                           link->getName().c_str());
-      //        continue;
-      //      }
-      //      if (collision_position.isNaN())
-      //      {
-      //        ROS_ERROR_THROTTLE(1.0,
-      //                           "collision position of %s contains NaNs. "
-      //                           "Skipping render as long as the position is "
-      //                           "invalid.",
-      //                           link->getName().c_str());
-      //        continue;
-      //      }
       link->setCurrentTransform(it->second);
+      link->setStartTransform(it->second);
+      link->setEndTransform(it->second);
     }
     else
     {
@@ -958,6 +1130,44 @@ void VisualizationWidget::update(const TransformMap& transforms)
 
     LinkWidget* p_link = links_[joint->getParentLinkName()];
     joint->setTransforms(p_link->getPosition(), p_link->getOrientation());
+  }
+}
+
+void VisualizationWidget::setStartState(const TransformMap& transforms)
+{
+  for (auto& link_pair : links_)
+  {
+    LinkWidget* link = link_pair.second;
+
+    link->setToNormalMaterial();
+    auto it = transforms.find(link->getName());
+    if (it != transforms.end())
+    {
+      link->setStartTransform(it->second);
+    }
+    else
+    {
+      link->setToErrorMaterial();
+    }
+  }
+}
+
+void VisualizationWidget::setEndState(const TransformMap& transforms)
+{
+  for (auto& link_pair : links_)
+  {
+    LinkWidget* link = link_pair.second;
+
+    link->setToNormalMaterial();
+    auto it = transforms.find(link->getName());
+    if (it != transforms.end())
+    {
+      link->setEndTransform(it->second);
+    }
+    else
+    {
+      link->setToErrorMaterial();
+    }
   }
 }
 

--- a/tesseract_rviz/src/tesseract_manipulation_plugin/plugin_init.cpp
+++ b/tesseract_rviz/src/tesseract_manipulation_plugin/plugin_init.cpp
@@ -30,4 +30,4 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/tesseract_manipulation_plugin/tesseract_manipulation_display.h>
 
-CLASS_LOADER_REGISTER_CLASS(tesseract_rviz::TesseractManipulationDisplay, rviz::Display)
+CLASS_LOADER_REGISTER_CLASS(tesseract_rviz::TesseractManipulationDisplay, rviz_common::Display)

--- a/tesseract_rviz/src/tesseract_scene_plugin/plugin_init.cpp
+++ b/tesseract_rviz/src/tesseract_scene_plugin/plugin_init.cpp
@@ -40,4 +40,4 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/tesseract_scene_plugin/tesseract_scene_display.h>
 
-CLASS_LOADER_REGISTER_CLASS(tesseract_rviz::TesseractSceneDisplay, rviz::Display)
+CLASS_LOADER_REGISTER_CLASS(tesseract_rviz::TesseractSceneDisplay, rviz_common::Display)

--- a/tesseract_rviz/src/tesseract_scene_plugin/tesseract_scene_display.cpp
+++ b/tesseract_rviz/src/tesseract_scene_plugin/tesseract_scene_display.cpp
@@ -41,15 +41,15 @@
 #include "tesseract_rviz/render_tools/octomap_render.h"
 #include "tesseract_rviz/render_tools/state_visualization.h"
 
-#include <rviz/display_context.h>
+#include <rviz_common/display_context.hpp>
 #include <rviz/frame_manager.h>
-#include <rviz/properties/bool_property.h>
-#include <rviz/properties/color_property.h>
-#include <rviz/properties/enum_property.h>
-#include <rviz/properties/float_property.h>
-#include <rviz/properties/property.h>
-#include <rviz/properties/ros_topic_property.h>
-#include <rviz/properties/string_property.h>
+#include <rviz_common/properties/bool_property.hpp>
+#include <rviz_common/properties/color_property.hpp>
+#include <rviz_common/properties/enum_property.hpp>
+#include <rviz_common/properties/float_property.hpp>
+#include <rviz_common/properties/property.hpp>
+#include <rviz_common/properties/ros_topic_property.hpp>
+#include <rviz_common/properties/string_property.hpp>
 #include <rviz/visualization_manager.h>
 #include <tf/transform_listener.h>
 
@@ -64,14 +64,14 @@ namespace tesseract_rviz
 TesseractSceneDisplay::TesseractSceneDisplay(bool listen_to_planning_scene, bool show_scene_robot)
   : Display(), model_is_loading_(false), tesseract_scene_needs_render_(true), current_scene_time_(0.0f)
 {
-  move_group_ns_property_ = new rviz::StringProperty("Move Group Namespace",
+  move_group_ns_property_ = new rviz_common::properties::StringProperty("Move Group Namespace",
                                                      "",
                                                      "The name of the ROS namespace in "
                                                      "which the move_group node is running",
                                                      this,
                                                      SLOT(changedMoveGroupNS()),
                                                      this);
-  robot_description_property_ = new rviz::StringProperty("Robot Description",
+  robot_description_property_ = new rviz_common::properties::StringProperty("Robot Description",
                                                          "robot_description",
                                                          "The name of the ROS parameter where the URDF for the robot "
                                                          "is loaded",
@@ -81,7 +81,7 @@ TesseractSceneDisplay::TesseractSceneDisplay(bool listen_to_planning_scene, bool
 
   if (listen_to_planning_scene)
     planning_scene_topic_property_ =
-        new rviz::RosTopicProperty("Planning Scene Topic",
+        new rviz_common::properties::RosTopicProperty("Planning Scene Topic",
                                    "move_group/monitored_planning_scene",
                                    ros::message_traits::datatype<moveit_msgs::PlanningScene>(),
                                    "The topic on which the moveit_msgs::PlanningScene messages are "
@@ -94,23 +94,23 @@ TesseractSceneDisplay::TesseractSceneDisplay(bool listen_to_planning_scene, bool
 
   // Planning scene category
   // -------------------------------------------------------------------------------------------
-  scene_category_ = new rviz::Property("Scene Geometry", QVariant(), "", this);
+  scene_category_ = new rviz_common::properties::Property("Scene Geometry", QVariant(), "", this);
 
-  scene_name_property_ = new rviz::StringProperty("Scene Name",
+  scene_name_property_ = new rviz_common::properties::StringProperty("Scene Name",
                                                   "(noname)",
                                                   "Shows the name of the planning scene",
                                                   scene_category_,
                                                   SLOT(changedSceneName()),
                                                   this);
   scene_name_property_->setShouldBeSaved(false);
-  scene_enabled_property_ = new rviz::BoolProperty("Show Scene Geometry",
+  scene_enabled_property_ = new rviz_common::properties::BoolProperty("Show Scene Geometry",
                                                    true,
                                                    "Indicates whether planning scenes should be displayed",
                                                    scene_category_,
                                                    SLOT(changedSceneEnabled()),
                                                    this);
 
-  scene_alpha_property_ = new rviz::FloatProperty("Scene Alpha",
+  scene_alpha_property_ = new rviz_common::properties::FloatProperty("Scene Alpha",
                                                   0.9f,
                                                   "Specifies the alpha for the scene geometry",
                                                   scene_category_,
@@ -127,7 +127,7 @@ TesseractSceneDisplay::TesseractSceneDisplay(bool listen_to_planning_scene, bool
                                                   SLOT(changedSceneColor()),
                                                   this);
 
-  octree_render_property_ = new rviz::EnumProperty("Voxel Rendering",
+  octree_render_property_ = new rviz_common::properties::EnumProperty("Voxel Rendering",
                                                    "Occupied Voxels",
                                                    "Select voxel type.",
                                                    scene_category_,
@@ -138,13 +138,13 @@ TesseractSceneDisplay::TesseractSceneDisplay(bool listen_to_planning_scene, bool
   octree_render_property_->addOption("Free Voxels", OCTOMAP_FREE_VOXELS);
   octree_render_property_->addOption("All Voxels", OCTOMAP_FREE_VOXELS | OCTOMAP_OCCUPIED_VOXELS);
 
-  octree_coloring_property_ = new rviz::EnumProperty(
+  octree_coloring_property_ = new rviz_common::properties::EnumProperty(
       "Voxel Coloring", "Z-Axis", "Select voxel coloring mode", scene_category_, SLOT(changedOctreeColorMode()), this);
 
   octree_coloring_property_->addOption("Z-Axis", OCTOMAP_Z_AXIS_COLOR);
   octree_coloring_property_->addOption("Cell Probability", OCTOMAP_PROBABLILTY_COLOR);
 
-  scene_display_time_property_ = new rviz::FloatProperty("Scene Display Time",
+  scene_display_time_property_ = new rviz_common::properties::FloatProperty("Scene Display Time",
                                                          0.2f,
                                                          "The amount of wall-time to wait in between rendering "
                                                          "updates to the planning scene (if any)",
@@ -155,9 +155,9 @@ TesseractSceneDisplay::TesseractSceneDisplay(bool listen_to_planning_scene, bool
 
   if (show_scene_robot)
   {
-    robot_category_ = new rviz::Property("Scene Robot", QVariant(), "", this);
+    robot_category_ = new rviz_common::properties::Property("Scene Robot", QVariant(), "", this);
 
-    scene_robot_visual_enabled_property_ = new rviz::BoolProperty("Show Robot Visual",
+    scene_robot_visual_enabled_property_ = new rviz_common::properties::BoolProperty("Show Robot Visual",
                                                                   true,
                                                                   "Indicates whether the robot state specified by the "
                                                                   "planning scene "
@@ -167,7 +167,7 @@ TesseractSceneDisplay::TesseractSceneDisplay(bool listen_to_planning_scene, bool
                                                                   SLOT(changedSceneRobotVisualEnabled()),
                                                                   this);
 
-    scene_robot_collision_enabled_property_ = new rviz::BoolProperty("Show Robot Collision",
+    scene_robot_collision_enabled_property_ = new rviz_common::properties::BoolProperty("Show Robot Collision",
                                                                      false,
                                                                      "Indicates whether the robot state specified by "
                                                                      "the planning scene "
@@ -178,7 +178,7 @@ TesseractSceneDisplay::TesseractSceneDisplay(bool listen_to_planning_scene, bool
                                                                      SLOT(changedSceneRobotCollisionEnabled()),
                                                                      this);
 
-    robot_alpha_property_ = new rviz::FloatProperty("Robot Alpha",
+    robot_alpha_property_ = new rviz_common::properties::FloatProperty("Robot Alpha",
                                                     1.0f,
                                                     "Specifies the alpha for the robot links",
                                                     robot_category_,

--- a/tesseract_rviz/src/tesseract_state_plugin/plugin_init.cpp
+++ b/tesseract_rviz/src/tesseract_state_plugin/plugin_init.cpp
@@ -1,0 +1,8 @@
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <pluginlib/class_list_macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_rviz/tesseract_state_plugin/tesseract_state_display.h>
+
+PLUGINLIB_EXPORT_CLASS(tesseract_rviz::TesseractStateDisplay, rviz_common::Display)

--- a/tesseract_rviz/src/tesseract_state_plugin/tesseract_state_display.cpp
+++ b/tesseract_rviz/src/tesseract_state_plugin/tesseract_state_display.cpp
@@ -1,0 +1,127 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ioan Sucan */
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+
+//#include <eigen_conversions/eigen_msg.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/frame_manager_iface.hpp>
+//#include <rviz_common/visualization_manager.hpp>
+
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_rviz/tesseract_state_plugin/tesseract_state_display.h>
+
+namespace tesseract_rviz
+{
+TesseractStateDisplay::TesseractStateDisplay() : Display(), node_(new rclcpp::Node("tesseract_state_display"))
+{
+  tesseract_ = std::make_shared<tesseract::Tesseract>();
+  environment_monitor_ = std::make_shared<EnvironmentWidget>(this, this);
+  state_monitor_ = std::make_shared<JointStateMonitorWidget>(this, this);
+}
+
+TesseractStateDisplay::~TesseractStateDisplay() {}
+
+void TesseractStateDisplay::onInitialize()
+{
+  Display::onInitialize();
+  visualization_ = std::make_shared<VisualizationWidget>(scene_node_, context_, "Tesseract State", this);
+
+  environment_monitor_->onInitialize(visualization_, tesseract_, context_, node_, false);
+  state_monitor_->onInitialize(visualization_, tesseract_, context_, node_);
+
+  visualization_->setVisible(false);
+}
+
+void TesseractStateDisplay::reset()
+{
+  visualization_->clear();
+  Display::reset();
+
+  environment_monitor_->onReset();
+  state_monitor_->onReset();
+}
+
+void TesseractStateDisplay::onEnable()
+{
+  Display::onEnable();
+
+  environment_monitor_->onEnable();
+  state_monitor_->onEnable();
+}
+
+void TesseractStateDisplay::onDisable()
+{
+  environment_monitor_->onDisable();
+  state_monitor_->onDisable();
+
+  Display::onDisable();
+}
+
+void TesseractStateDisplay::update(float wall_dt, float ros_dt)
+{
+  Display::update(wall_dt, ros_dt);
+
+  environment_monitor_->onUpdate();
+  state_monitor_->onUpdate();
+}
+
+// ******************************************************************************************
+// Calculate Offset Position
+// ******************************************************************************************
+// void TesseractStateDisplay::calculateOffsetPosition()
+//{
+//  if (!env_)
+//    return;
+
+//  Ogre::Vector3 position;
+//  Ogre::Quaternion orientation;
+
+//  context_->getFrameManager()->getTransform(env_->getRootLinkName(), ros::Time(0), position, orientation);
+//  scene_node_->setPosition(position);
+//  scene_node_->setOrientation(orientation);
+//}
+
+// void TesseractStateDisplay::fixedFrameChanged()
+//{
+//  Display::fixedFrameChanged();
+//  calculateOffsetPosition();
+//}
+
+}  // namespace tesseract_rviz

--- a/tesseract_rviz/src/tesseract_trajectory_plugin/plugin_init.cpp
+++ b/tesseract_rviz/src/tesseract_trajectory_plugin/plugin_init.cpp
@@ -36,9 +36,9 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <class_loader/class_loader.hpp>
+#include <pluginlib/class_list_macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h>
 
-CLASS_LOADER_REGISTER_CLASS(tesseract_rviz::TesseractTrajectoryDisplay, rviz::Display)
+CLASS_LOADER_REGISTER_CLASS(tesseract_rviz::TesseractTrajectoryDisplay, rviz_common::Display)

--- a/tesseract_rviz/src/tesseract_trajectory_plugin/plugin_init.cpp
+++ b/tesseract_rviz/src/tesseract_trajectory_plugin/plugin_init.cpp
@@ -36,7 +36,7 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h>

--- a/tesseract_rviz/src/tesseract_trajectory_plugin/plugin_init.cpp
+++ b/tesseract_rviz/src/tesseract_trajectory_plugin/plugin_init.cpp
@@ -41,4 +41,4 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h>
 
-CLASS_LOADER_REGISTER_CLASS(tesseract_rviz::TesseractTrajectoryDisplay, rviz_common::Display)
+PLUGINLIB_EXPORT_CLASS(tesseract_rviz::TesseractTrajectoryDisplay, rviz_common::Display)

--- a/tesseract_rviz/src/tesseract_trajectory_plugin/tesseract_trajectory_display.cpp
+++ b/tesseract_rviz/src/tesseract_trajectory_plugin/tesseract_trajectory_display.cpp
@@ -43,10 +43,11 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h>
+#include <rviz_common/display_context.hpp>
 
 namespace tesseract_rviz
 {
-TesseractTrajectoryDisplay::TesseractTrajectoryDisplay() : node_{std::make_shared<rclcpp::Node>("tesseract_trajectory_display")}
+TesseractTrajectoryDisplay::TesseractTrajectoryDisplay()
 {
   env_ = std::make_shared<tesseract_environment::Environment>();
   environment_monitor_ = std::make_shared<EnvironmentWidget>(this, this);
@@ -62,6 +63,7 @@ void TesseractTrajectoryDisplay::onInitialize()
   visualization_ = std::make_shared<VisualizationWidget>(scene_node_, context_, "Tesseract State", this);
   visualization_->setCurrentStateVisible(false);
 
+  node_ = context_->getRosNodeAbstraction().lock()->get_raw_node();
   environment_monitor_->onInitialize(visualization_, env_, context_, node_, false);
   state_monitor_->onInitialize(visualization_, env_, context_, node_);
   trajectory_monitor_->onInitialize(visualization_, env_, context_, node_);

--- a/tesseract_rviz/src/tesseract_trajectory_plugin/tesseract_trajectory_display.cpp
+++ b/tesseract_rviz/src/tesseract_trajectory_plugin/tesseract_trajectory_display.cpp
@@ -38,20 +38,23 @@
 */
 
 #include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <tesseract_rosutils/utils.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h>
 
 namespace tesseract_rviz
 {
-TesseractTrajectoryDisplay::TesseractTrajectoryDisplay() : Display() , node_(new rclcpp::Node("tesseract_trajectory_display"))
+TesseractTrajectoryDisplay::TesseractTrajectoryDisplay() : node_{std::make_shared<rclcpp::Node>("tesseract_trajectory_display")}
 {
-  tesseract_ = std::make_shared<tesseract::Tesseract>();
+  env_ = std::make_shared<tesseract_environment::Environment>();
   environment_monitor_ = std::make_shared<EnvironmentWidget>(this, this);
   state_monitor_ = std::make_shared<JointStateMonitorWidget>(this, this);
   trajectory_monitor_ = std::make_shared<TrajectoryMonitorWidget>(this, this);
 }
 
-TesseractTrajectoryDisplay::~TesseractTrajectoryDisplay() {}
+TesseractTrajectoryDisplay::~TesseractTrajectoryDisplay() = default;
 void TesseractTrajectoryDisplay::onInitialize()
 {
   Display::onInitialize();
@@ -59,9 +62,9 @@ void TesseractTrajectoryDisplay::onInitialize()
   visualization_ = std::make_shared<VisualizationWidget>(scene_node_, context_, "Tesseract State", this);
   visualization_->setCurrentStateVisible(false);
 
-  environment_monitor_->onInitialize(visualization_, tesseract_, context_, node_, false);
-  state_monitor_->onInitialize(visualization_, tesseract_, context_, node_);
-  trajectory_monitor_->onInitialize(visualization_, tesseract_, context_, node_);
+  environment_monitor_->onInitialize(visualization_, env_, context_, node_, false);
+  state_monitor_->onInitialize(visualization_, env_, context_, node_);
+  trajectory_monitor_->onInitialize(visualization_, env_, context_, node_);
 
   visualization_->setVisible(false);
 }
@@ -102,10 +105,12 @@ void TesseractTrajectoryDisplay::update(float wall_dt, float ros_dt)
   trajectory_monitor_->onUpdate(wall_dt);
 }
 
-//void TesseractTrajectoryDisplay::setName(const QString& name)
-//{
-//  BoolProperty::setName(name);
-//  trajectory_monitor_->onNameChange(name);
-//}
+/*
+void TesseractTrajectoryDisplay::setName(const QString& name)
+{
+  BoolProperty::setName(name);
+  trajectory_monitor_->onNameChange(name);
+}
+*/
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/src/tesseract_trajectory_plugin/tesseract_trajectory_display.cpp
+++ b/tesseract_rviz/src/tesseract_trajectory_plugin/tesseract_trajectory_display.cpp
@@ -38,24 +38,20 @@
 */
 
 #include <tesseract_common/macros.h>
-TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <ros/package.h>
-#include <tesseract_rosutils/utils.h>
-TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h>
 
 namespace tesseract_rviz
 {
-TesseractTrajectoryDisplay::TesseractTrajectoryDisplay()
+TesseractTrajectoryDisplay::TesseractTrajectoryDisplay() : Display() , node_(new rclcpp::Node("tesseract_trajectory_display"))
 {
-  env_ = std::make_shared<tesseract_environment::Environment>();
+  tesseract_ = std::make_shared<tesseract::Tesseract>();
   environment_monitor_ = std::make_shared<EnvironmentWidget>(this, this);
   state_monitor_ = std::make_shared<JointStateMonitorWidget>(this, this);
   trajectory_monitor_ = std::make_shared<TrajectoryMonitorWidget>(this, this);
 }
 
-TesseractTrajectoryDisplay::~TesseractTrajectoryDisplay() = default;
+TesseractTrajectoryDisplay::~TesseractTrajectoryDisplay() {}
 void TesseractTrajectoryDisplay::onInitialize()
 {
   Display::onInitialize();
@@ -63,9 +59,9 @@ void TesseractTrajectoryDisplay::onInitialize()
   visualization_ = std::make_shared<VisualizationWidget>(scene_node_, context_, "Tesseract State", this);
   visualization_->setCurrentStateVisible(false);
 
-  environment_monitor_->onInitialize(visualization_, env_, context_, nh_, false);
-  state_monitor_->onInitialize(visualization_, env_, context_, nh_);
-  trajectory_monitor_->onInitialize(visualization_, env_, context_, nh_);
+  environment_monitor_->onInitialize(visualization_, tesseract_, context_, node_, false);
+  state_monitor_->onInitialize(visualization_, tesseract_, context_, node_);
+  trajectory_monitor_->onInitialize(visualization_, tesseract_, context_, node_);
 
   visualization_->setVisible(false);
 }
@@ -106,10 +102,10 @@ void TesseractTrajectoryDisplay::update(float wall_dt, float ros_dt)
   trajectory_monitor_->onUpdate(wall_dt);
 }
 
-void TesseractTrajectoryDisplay::setName(const QString& name)
-{
-  BoolProperty::setName(name);
-  trajectory_monitor_->onNameChange(name);
-}
+//void TesseractTrajectoryDisplay::setName(const QString& name)
+//{
+//  BoolProperty::setName(name);
+//  trajectory_monitor_->onNameChange(name);
+//}
 
 }  // namespace tesseract_rviz

--- a/tesseract_rviz/src/test.cpp
+++ b/tesseract_rviz/src/test.cpp
@@ -1,9 +1,9 @@
-//#include "tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h"
+#include "tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h"
 #include "tesseract_rviz/environment_state_plugin/environment_state_display.h"
 
 int main(int /*argc*/, char** /*argv[]*/)
 {
-  //tesseract_rviz::TesseractTrajectoryDisplay test_trajectory_display;
+  tesseract_rviz::TesseractTrajectoryDisplay test_trajectory_display;
   tesseract_rviz::EnvironmentStateDisplay test_state_display;
 
   return 0;

--- a/tesseract_rviz/src/test.cpp
+++ b/tesseract_rviz/src/test.cpp
@@ -1,7 +1,10 @@
-#include "tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h"
+//#include "tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h"
 #include "tesseract_rviz/environment_state_plugin/environment_state_display.h"
+
 int main(int /*argc*/, char** /*argv[]*/)
 {
-  tesseract_rviz::TesseractTrajectoryDisplay test_trajectory_display;
+  //tesseract_rviz::TesseractTrajectoryDisplay test_trajectory_display;
   tesseract_rviz::EnvironmentStateDisplay test_state_display;
+
+  return 0;
 }

--- a/tesseract_rviz/tesseract_rviz_manipulation_plugin_description.xml
+++ b/tesseract_rviz/tesseract_rviz_manipulation_plugin_description.xml
@@ -1,5 +1,5 @@
 <library path="libtesseract_rviz_manipulation_plugin">
-  <class name="tesseract_rviz/TesseractManipulation" type="tesseract_rviz::TesseractManipulationDisplay" base_class_type="rviz::Display">
+  <class name="tesseract_rviz/TesseractManipulation" type="tesseract_rviz::TesseractManipulationDisplay" base_class_type="rviz_common::Display">
     <description>
       Add interactive marker for manipulating the robot.
     </description>

--- a/tesseract_rviz/tesseract_rviz_state_plugin_description.xml
+++ b/tesseract_rviz/tesseract_rviz_state_plugin_description.xml
@@ -1,5 +1,5 @@
 <library path="libtesseract_rviz_state_plugin">
-  <class name="tesseract_rviz/EnvironmentState" type="tesseract_rviz::EnvironmentStateDisplay" base_class_type="rviz::Display">
+  <class name="tesseract_rviz/TesseractState" type="tesseract_rviz::TesseractStateDisplay" base_class_type="rviz_common::Display">
     <description>
       Displays a tesseract environment state.
     </description>

--- a/tesseract_rviz/tesseract_rviz_state_plugin_description.xml
+++ b/tesseract_rviz/tesseract_rviz_state_plugin_description.xml
@@ -1,5 +1,5 @@
-<library path="libtesseract_rviz_state_plugin">
-  <class name="tesseract_rviz/TesseractState" type="tesseract_rviz::TesseractStateDisplay" base_class_type="rviz_common::Display">
+<library path="tesseract_rviz_state_plugin">
+  <class name="tesseract_rviz/EnvironmentState" type="tesseract_rviz::EnvironmentStateDisplay" base_class_type="rviz_common::Display">
     <description>
       Displays a tesseract environment state.
     </description>

--- a/tesseract_rviz/tesseract_rviz_trajectory_plugin_description.xml
+++ b/tesseract_rviz/tesseract_rviz_trajectory_plugin_description.xml
@@ -1,5 +1,5 @@
 <library path="libtesseract_rviz_trajectory_plugin">
-  <class name="tesseract_rviz/TesseractTrajectory" type="tesseract_rviz::TesseractTrajectoryDisplay" base_class_type="rviz::Display">
+  <class name="tesseract_rviz/TesseractTrajectory" type="tesseract_rviz::TesseractTrajectoryDisplay" base_class_type="rviz_common::Display">
     <description>
       Displays a tesseract environment state.
     </description>

--- a/tesseract_rviz/tesseract_rviz_trajectory_plugin_description.xml
+++ b/tesseract_rviz/tesseract_rviz_trajectory_plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="libtesseract_rviz_trajectory_plugin">
+<library path="tesseract_rviz_trajectory_plugin">
   <class name="tesseract_rviz/TesseractTrajectory" type="tesseract_rviz::TesseractTrajectoryDisplay" base_class_type="rviz_common::Display">
     <description>
       Displays a tesseract environment state.


### PR DESCRIPTION
Based off @mpowelson's work in #11 with updates to match `tesseract_ros` changes since this `ros2-dev` branch was formed.

This provides working environment state and trajectory monitor displays. Some remaining known issues:
- rviz crashes when either of the display is removed. It seems to be because a slot is called on an already deleted `QObject` (the `VisualizationWidget`) but I haven't been able to figure out why.
- When playing a received trajectory it was very jerky for me, with the robot jumping between states that are quite far apart. Don't have any ideas right now what's happening.

@Levi-Armstrong @marip8 if you guys want to take a look at all that would be great. Given the size of the changes though, we may just want to merge straight away and continue debugging.