### PR TITLE
Update to tesseract 0.19

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -6,23 +6,23 @@ repositories:
   tesseract:
     type: git
     url: https://github.com/tesseract-robotics/tesseract.git
-    version: 0.18.2
+    version: 0.19.2
   trajopt:
     type: git
     url: https://github.com/tesseract-robotics/trajopt.git
-    version: 0.6.0
+    version: 0.6.1
   tesseract_planning:
     type: git
     url: https://github.com/tesseract-robotics/tesseract_planning.git
-    version: 0.18.5
+    version: 0.19.1
   tesseract_qt:
     type: git
     url: https://github.com/tesseract-robotics/tesseract_qt.git
-    version: 0.18.4
+    version: 0.19.0
   descartes_light:
     type: git
     url: https://github.com/swri-robotics/descartes_light.git
-    version: 0.3.2
+    version: 0.4.2
   opw_kinematics:
     type: git
     url: https://github.com/Jmeyer1292/opw_kinematics.git

--- a/dependencies_unstable.repos
+++ b/dependencies_unstable.repos
@@ -30,7 +30,7 @@ repositories:
   ifopt:
     type: git
     url: https://github.com/ethz-adrl/ifopt.git
-    version: master
+    version: 2.1.3
   taskflow:
     type: git
     url: https://github.com/taskflow/taskflow.git

--- a/dependencies_with_ext.repos
+++ b/dependencies_with_ext.repos
@@ -6,23 +6,23 @@ repositories:
   tesseract:
     type: git
     url: https://github.com/tesseract-robotics/tesseract.git
-    version: 0.18.2
+    version: 0.19.2
   trajopt:
     type: git
     url: https://github.com/tesseract-robotics/trajopt.git
-    version: 0.6.0
+    version: 0.6.1
   tesseract_planning:
     type: git
     url: https://github.com/tesseract-robotics/tesseract_planning.git
-    version: 0.18.5
+    version: 0.19.1
   tesseract_qt:
     type: git
     url: https://github.com/tesseract-robotics/tesseract_qt.git
-    version: 0.18.4
+    version: 0.19.0
   descartes_light:
     type: git
     url: https://github.com/swri-robotics/descartes_light.git
-    version: 0.3.2
+    version: 0.4.2
   opw_kinematics:
     type: git
     url: https://github.com/Jmeyer1292/opw_kinematics.git


### PR DESCRIPTION
No real changes are necessary to be compatible with tesseract 0.19, aside from updating the .repos files

Builds on #68 