### PR TITLE
Fixed issue where wrong mode was loaded on startup

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -6,7 +6,7 @@ repositories:
   tesseract:
     type: git
     url: https://github.com/tesseract-robotics/tesseract.git
-    version: 0.19.2
+    version: 0.20.0
   trajopt:
     type: git
     url: https://github.com/tesseract-robotics/trajopt.git
@@ -14,11 +14,11 @@ repositories:
   tesseract_planning:
     type: git
     url: https://github.com/tesseract-robotics/tesseract_planning.git
-    version: 0.19.1
+    version: 0.20.0
   tesseract_qt:
     type: git
     url: https://github.com/tesseract-robotics/tesseract_qt.git
-    version: 0.19.0
+    version: 0.20.0
   descartes_light:
     type: git
     url: https://github.com/swri-robotics/descartes_light.git

--- a/tesseract_rviz/src/environment_monitor_properties.cpp
+++ b/tesseract_rviz/src/environment_monitor_properties.cpp
@@ -159,15 +159,19 @@ void EnvironmentMonitorProperties::load(const rviz_common::Config& config)
   if (config.mapGetString("tesseract::EnvMonitorURDFDescription", &urdf_description))
     data_->urdf_description_string_property->setString(urdf_description);
 
-  QString topic;
-  if (config.mapGetString("tesseract::EnvMonitorTopic", &topic))
-    data_->environment_topic_property->setString(topic);
+  QString env_mon_topic;
+  if (config.mapGetString("tesseract::EnvMonitorTopic", &env_mon_topic))
+    data_->environment_topic_property->setString(env_mon_topic);
 
-  if (config.mapGetString("tesseract::EnvMonitorSnapshotTopic", &topic))
-    data_->environment_snapshot_topic_property->setString(topic);
+  QString snapshot_topic;
+  if (config.mapGetString("tesseract::EnvMonitorSnapshotTopic", &snapshot_topic))
+    data_->environment_snapshot_topic_property->setString(snapshot_topic);
 
-  if (config.mapGetString("tesseract::EnvMonitorJointStateTopic", &topic))
-    data_->joint_state_topic_property->setString(topic);
+  QString joint_state_topic;
+  if (config.mapGetString("tesseract::EnvMonitorJointStateTopic", &joint_state_topic))
+    data_->joint_state_topic_property->setString(joint_state_topic);
+
+  onDisplayModeChanged();
 }
 
 void EnvironmentMonitorProperties::save(rviz_common::Config config) const


### PR DESCRIPTION
The `load()` method appears to be called after the `onInitialize()` method. The `onDisplayModeChanged()` method, which is responsible for updating the display, was previously only called at the end of `onInitialize()`, but the environment mode isn't set from the config file until `load()` is called. This lead to an issue where the display mode would be on the right dropdown selection in RVIZ, but the back end would be on the wrong mode. The only way to address it was to toggle back and forth between modes after launch. This should fix that issue.