### PR TITLE
EnvironmentMonitor settings cleanup

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -6,7 +6,7 @@ repositories:
   tesseract:
     type: git
     url: https://github.com/tesseract-robotics/tesseract.git
-    version: 0.19.2
+    version: 0.20.0
   trajopt:
     type: git
     url: https://github.com/tesseract-robotics/trajopt.git
@@ -14,11 +14,11 @@ repositories:
   tesseract_planning:
     type: git
     url: https://github.com/tesseract-robotics/tesseract_planning.git
-    version: 0.19.1
+    version: 0.20.0
   tesseract_qt:
     type: git
     url: https://github.com/tesseract-robotics/tesseract_qt.git
-    version: 0.19.0
+    version: 0.20.0
   descartes_light:
     type: git
     url: https://github.com/swri-robotics/descartes_light.git

--- a/tesseract_rviz/include/tesseract_rviz/environment_display.h
+++ b/tesseract_rviz/include/tesseract_rviz/environment_display.h
@@ -16,9 +16,6 @@ public:
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
 
-  void load(const rviz_common::Config& config) override;
-  void save(rviz_common::Config config) const override;
-
 public Q_SLOTS:
   void onEnableChanged() override;
   void onComponentInfoChanged(std::shared_ptr<const tesseract_gui::ComponentInfo> component_info);

--- a/tesseract_rviz/include/tesseract_rviz/environment_monitor_properties.h
+++ b/tesseract_rviz/include/tesseract_rviz/environment_monitor_properties.h
@@ -50,8 +50,7 @@ public:
    */
   std::shared_ptr<const tesseract_gui::ComponentInfo> getComponentInfo() const;
 
-  void load(const rviz_common::Config& config);
-  void save(rviz_common::Config config) const;
+  void resetMonitor();
 
 Q_SIGNALS:
   void componentInfoChanged(std::shared_ptr<const tesseract_gui::ComponentInfo> component_info);

--- a/tesseract_rviz/include/tesseract_rviz/workbench_display.h
+++ b/tesseract_rviz/include/tesseract_rviz/workbench_display.h
@@ -16,9 +16,6 @@ public:
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
 
-  void load(const rviz_common::Config& config) override;
-  void save(rviz_common::Config config) const override;
-
 public Q_SLOTS:
   void onEnableChanged() override;
   void onComponentInfoChanged(std::shared_ptr<const tesseract_gui::ComponentInfo> component_info);

--- a/tesseract_rviz/src/environment_display.cpp
+++ b/tesseract_rviz/src/environment_display.cpp
@@ -101,18 +101,6 @@ void EnvironmentDisplay::update(float wall_dt, float ros_dt)
                             new tesseract_gui::events::PreRender(data_->widget->getComponentInfo()->getSceneName()));
 }
 
-void EnvironmentDisplay::load(const rviz_common::Config& config)
-{
-  rviz_common::Display::load(config);
-  data_->monitor_properties->load(config);
-}
-
-void EnvironmentDisplay::save(rviz_common::Config config) const
-{
-  data_->monitor_properties->save(config);
-  rviz_common::Display::save(config);
-}
-
 void EnvironmentDisplay::onEnable()
 {
   Display::onEnable();

--- a/tesseract_rviz/src/workbench_display.cpp
+++ b/tesseract_rviz/src/workbench_display.cpp
@@ -121,18 +121,6 @@ void WorkbenchDisplay::update(float wall_dt, float ros_dt)
                             new tesseract_gui::events::PreRender(data_->widget->getComponentInfo()->getSceneName()));
 }
 
-void WorkbenchDisplay::load(const rviz_common::Config& config)
-{
-  rviz_common::Display::load(config);
-  data_->monitor_properties->load(config);
-}
-
-void WorkbenchDisplay::save(rviz_common::Config config) const
-{
-  data_->monitor_properties->save(config);
-  rviz_common::Display::save(config);
-}
-
 void WorkbenchDisplay::onEnableChanged()
 {
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));


### PR DESCRIPTION
- Removed load() and save() methods, as properties are loaded automatically. This also gets rid of the redundant tesseract::EnvMonitor... properties in the .rviz settings file
- Moved (and unified) duplicate code to resetMonitor() method
- Only allow executing on...() methods when the correct mode is selected
- Added constants for enum propery options
- Removed onJointStateTopicChanged() from onDisplayModeChanged(), as the other on...() methods will call this anyway
