### PR TITLE
CI Update

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -82,7 +82,7 @@ jobs:
             echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
           fi
 
-      - uses: 'ros-industrial/industrial_ci@master'
+      - uses: 'tesseract-robotics/industrial_ci@0109bf3523050402490b56e19c9554e7d7c5379f'
         env:
           ROS_DISTRO: ${{ matrix.distro }}
           ROS_REPO: main

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -90,11 +90,12 @@ jobs:
           ROSDEP_SKIP_KEYS: "catkin taskflow fcl gz-common5 gz-math7 gz-rendering7 qt_advanced_docking"
           PARALLEL_TESTS: false
           NOT_TEST_BUILD: true
+          BASEDIR: /opt
           PREFIX: ${{ github.repository }}_
           UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release -DBUILD_RENDERING=OFF -DBUILD_STUDIO=OFF"
           TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}"
-          BEFORE_RUN_TARGET_TEST_EMBED: "source /root/target_ws/install/local_setup.bash"
-          AFTER_SCRIPT: 'rm -r $BASEDIR/${PREFIX}upstream_ws/build $BASEDIR/${PREFIX}target_ws/build'
+          BEFORE_RUN_TARGET_TEST_EMBED: "source ${BASEDIR}/${PREFIX}target_ws/install/local_setup.bash"
+          AFTER_SCRIPT: 'rm -r ${BASEDIR}/${PREFIX}upstream_ws/build ${BASEDIR}/${PREFIX}target_ws/build'
           DOCKER_COMMIT: ${{ steps.meta.outputs.tags }}
 
       - name: Push post-build Docker

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -50,7 +50,7 @@ jobs:
           restore-keys: |
             ${{ env.matrix.distro }}-ccache-
 
-      - uses: 'ros-industrial/industrial_ci@master'
+      - uses: 'tesseract-robotics/industrial_ci@0109bf3523050402490b56e19c9554e7d7c5379f'
         env:
           ROS_DISTRO: ${{ matrix.distro }}
           ROS_REPO: main

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -8,9 +8,6 @@ on:
   schedule:
     - cron: '0 5 * * 6'
   workflow_dispatch:
-  release:
-    types:
-      - released
 
 jobs:
   industrial_ci:


### PR DESCRIPTION
- Changes the nominal CI build directory to `/opt`, which, unlike `/root`, is accessible to non-root users
  - This is valuable for using CI-built docker images in deployment where the docker containers are run with non-root users to support graphics
- Changes to use `tesseract` version of ICI which performs shallow cloning with VCS, which should reduce the time required to pull dependencies and reduce the overall size of the built docker image