### PR TITLE
Added docker files

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,69 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'docker/Dockerfile'
+      - '.github/workflows/docker.yml'
+  release:
+    types:
+      - released
+
+jobs:
+  ci:
+    name: ${{ matrix.distro }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: foxy
+            os: focal
+          - distro: humble
+            os: jammy
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+      PUSH_DOCKER_IMAGE: ${{ github.ref == 'refs/heads/master' || github.event_name == 'release' }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker meta-information
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+            prefix=
+            suffix=
+          tags: |
+            type=ref,event=branch,prefix=${{ matrix.distro }}-
+            type=ref,event=pr,prefix=${{ matrix.distro }}-
+            type=semver,pattern={{major}}.{{minor}},prefix=${{ matrix.distro }}-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          build-args: |
+            TAG=${{ matrix.os }}-0.21
+            ROS_DISTRO=${{ matrix.distro }}
+          push: ${{ env.PUSH_DOCKER_IMAGE }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+ARG TAG
+FROM ghcr.io/tesseract-robotics/tesseract_qt:${TAG}
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND noninteractive
+
+USER root
+
+# Install ROS
+ARG ROS_DISTRO
+RUN apt install -y \
+  ros-${ROS_DISTRO}-ros-base \
+  ros-${ROS_DISTRO}-ament-cmake \
+  ros-${ROS_DISTRO}-ros2launch \
+  ros-${ROS_DISTRO}-launch-ros \
+  ros-${ROS_DISTRO}-launch-xml \
+  ros-${ROS_DISTRO}-launch-yaml
+
+# Bind mount the source directory so as not to unnecessarily copy source code into the docker image
+ARG WORKSPACE_DIR=/opt/tesseract_ros2
+RUN --mount=type=bind,target=${WORKSPACE_DIR}/src/tesseract_ros2 \
+  source /opt/ros/${ROS_DISTRO}/setup.bash \
+  && source /opt/tesseract_qt/install/setup.bash \
+  && rosdep update --include-eol-distros \
+  && rosdep install \
+    --from-paths ${WORKSPACE_DIR}/src \
+    -iry
+
+# Build the repository
+# Bind mount the source directory so as not to unnecessarily copy source code into the docker image
+RUN --mount=type=bind,target=${WORKSPACE_DIR}/src/tesseract_ros2 \
+  source /opt/tesseract_qt/install/setup.bash \
+  && source /opt/ros/${ROS_DISTRO}/setup.bash \
+  && cd ${WORKSPACE_DIR} \ 
+  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release \
+  && rm -rf build log

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,12 @@ USER root
 
 # Install ROS
 ARG ROS_DISTRO
+
+# Add the ROS sources
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null \
+  && apt update -qq
+
 RUN apt install -y \
   ros-${ROS_DISTRO}-ros-base \
   ros-${ROS_DISTRO}-ament-cmake \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,14 @@ RUN apt install -y \
 
 # Bind mount the source directory so as not to unnecessarily copy source code into the docker image
 ARG WORKSPACE_DIR=/opt/tesseract_ros2
+
+# Install the latest version of octomap_msgs for Humble and beyond
+RUN --mount=type=bind,target=${WORKSPACE_DIR}/src/tesseract_ros2 \
+  if [[ "${ROS_DISTRO}" > "foxy" ]]; then \
+  cd ${WORKSPACE_DIR} \
+  && vcs import src < src/tesseract_ros2/.github/workflows/dependencies.repos --shallow ; \
+  fi
+
 RUN --mount=type=bind,target=${WORKSPACE_DIR}/src/tesseract_ros2 \
   source /opt/ros/${ROS_DISTRO}/setup.bash \
   && source /opt/tesseract_qt/install/setup.bash \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,28 @@
+# Tesseract Planning Docker
+
+## Create the Docker image
+### Download
+Download a pre-built Docker image for this bridge from the container registry:
+
+```
+docker login ghcr.io
+docker pull ghcr.io/tesseract-robotics/tesseract_planning:<tag>
+```
+
+### Build
+Build the Docker image using `docker-compose`:
+
+```commandLine
+cd docker
+docker compose build
+```
+
+## Run the docker image
+Run the Docker image using `docker-compose`:
+
+```commandLine
+cd docker
+CURRENT_UID=$(id -u):$(id -g) docker compose up
+```
+
+> Note: by default the docker image runs as a non-root user, so the environment variable `CURRENT_UID` must be supplied as shown above

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+services:
+  tesseract:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      args:
+        - TAG=focal-0.20
+        - ROS_DISTRO=foxy
+    environment:
+      DISPLAY: $DISPLAY
+      XAUTHORITY: $XAUTHORITY
+      NVIDIA_DRIVER_CAPABILITIES: all
+      ROS_LOG_DIR: /tmp
+    container_name: tesseract_ros2
+    image: ghcr.io/tesseract-robotics/tesseract_ros2:foxy-0.20
+    stdin_open: true
+    tty: true
+    network_mode: host
+    user: ${CURRENT_UID}  # CURRENT_UID=$(id -u):$(id -g)
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - /etc/hosts:/etc/hosts
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]


### PR DESCRIPTION
This PR adds a `Dockerfile` and Docker compose file for building `tesseract_ros2` on top of `tesseract_qt`. This image is intended to be able to function as a base for `tesseract_ros2`-based applications.

Note this Docker image builds on top of the `tesseract_qt` deploy image from https://github.com/tesseract-robotics/tesseract_qt/pull/87 so as to minimize build time and layer size.