### PR TITLE
Fix urdf version example based off latest updates

### DIFF
--- a/gh_pages/_source/tesseract_urdf_doc.rst
+++ b/gh_pages/_source/tesseract_urdf_doc.rst
@@ -31,7 +31,7 @@ Change URDF Version
 
 .. code-block:: xml
 
-   <robot name="kuka_iiwa" version="2">
+   <robot name="kuka_iiwa" tesseract_version="2">
    </robot>
 
 


### PR DESCRIPTION
This is based off the change in https://github.com/tesseract-robotics/tesseract/pull/979