### PR TITLE
Pass description field to trajectory objects

### DIFF
--- a/tesseract_rosutils/src/utils.cpp
+++ b/tesseract_rosutils/src/utils.cpp
@@ -1725,6 +1725,8 @@ void toMsg(const tesseract_msgs::msg::EnvironmentState::SharedPtr& state_msg,
 
 void toMsg(tesseract_msgs::msg::JointTrajectory& traj_msg, const tesseract_common::JointTrajectory& traj)
 {
+  traj_msg.description = traj.description;
+
   for (const auto& js : traj)
   {
     assert(js.joint_names.size() == static_cast<unsigned>(js.position.size()));
@@ -1752,6 +1754,7 @@ void toMsg(tesseract_msgs::msg::JointTrajectory& traj_msg, const tesseract_commo
 tesseract_common::JointTrajectory fromMsg(const tesseract_msgs::msg::JointTrajectory& traj_msg)
 {
   tesseract_common::JointTrajectory trajectory;
+  trajectory.description = traj_msg.description;
   for (const auto& js_msg : traj_msg.states)
   {
     assert(js_msg.joint_names.size() == static_cast<unsigned>(js_msg.position.size()));

--- a/tesseract_rviz/src/joint_trajectory_monitor_properties.cpp
+++ b/tesseract_rviz/src/joint_trajectory_monitor_properties.cpp
@@ -98,9 +98,11 @@ struct JointTrajectoryMonitorProperties::Implementation
       {
         tesseract_common::JointTrajectory joint_trajectory = tesseract_rosutils::fromMsg(joint_trajectory_msg);
         trajectory_set.appendJointTrajectory(joint_trajectory);
-        tesseract_gui::events::JointTrajectoryAdd event(component_info, trajectory_set);
-        QApplication::sendEvent(qApp, &event);
       }
+
+      trajectory_set.setDescription(msg->description);
+      tesseract_gui::events::JointTrajectoryAdd event(component_info, trajectory_set);
+      QApplication::sendEvent(qApp, &event);
     }
     catch (...)
     {


### PR DESCRIPTION
- Fixes issue where multiple trajectory sets where published every time a trajectory was appended to it
- Ensures the description field is copied to and from the tesseract ROS messages.