### PR TITLE
Add ability to reset marker counter without clearing

### DIFF
--- a/tesseract_rosutils/include/tesseract_rosutils/plotting.h
+++ b/tesseract_rosutils/include/tesseract_rosutils/plotting.h
@@ -94,6 +94,8 @@ public:
 
   const std::string& getRootLink() const;
 
+  void resetCounter();
+
   static visualization_msgs::msg::MarkerArray getMarkerAxisMsg(int& id_counter,
                                                                const std::string& frame_id,
                                                                const std::string& ns,

--- a/tesseract_rosutils/src/plotting.cpp
+++ b/tesseract_rosutils/src/plotting.cpp
@@ -355,6 +355,8 @@ void ROSPlotting::waitForInput(std::string message)
 
 const std::string& ROSPlotting::getRootLink() const { return root_link_; }
 
+void ROSPlotting::resetCounter() { marker_counter_ = 0; }
+
 visualization_msgs::msg::Marker ROSPlotting::getMarkerArrowMsg(int& id_counter,
                                                                const std::string& frame_id,
                                                                const std::string& ns,


### PR DESCRIPTION
Since the topics in ROS2 aren't latching and I want to be able to check and uncheck a topic in RViz this allows me to have a timer callback constantly publishing the marker without having `marker_counter_` go up forever. Previously I was calling `clear()` which accomplished this, but the clear method wasn't properly implemented and now it's causing my toolpath to flash on and off which is very annoying.
```C++
void onPublishToolpathTimer()
{
  plotter_->resetCounter();
  plotter_->plotMarker(
    tesseract_visualization::ToolpathMarker(
      my_toolpath), "planning_toolpath");
}
```