### PR TITLE
Change docker tag to match version, not hardcoded

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,6 +64,8 @@ jobs:
           TAG="${{ steps.meta.outputs.tags }}"
           # Replace all occurrences of matrix.distro with matrix.os in the generated tags. e.g. humble->jammy
           TAG="${TAG//${{ matrix.distro }}/${{ matrix.os }}}"
+          # Export TAG to the environment variable for use in subsequent steps
+          echo "TAG=$TAG" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,7 +64,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           build-args: |
-            TAG=${{ matrix.os }}-0.21
+            TAG=${{ steps.meta.outputs.version }}
             ROS_DISTRO=${{ matrix.distro }}
           push: ${{ env.PUSH_DOCKER_IMAGE }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,13 +58,20 @@ jobs:
             type=raw,event=pr,prefix=${{ matrix.distro }}-,value=master
             type=semver,pattern={{major}}.{{minor}},prefix=${{ matrix.distro }}-
 
+      - name: Set TAG environment variable based on metadata output
+        run: |
+          # All prior tesseract packages are on an OS level, being a ROS package, this is on a ROS distro level
+          TAG="${{ steps.meta.outputs.tags }}"
+          # Replace all occurrences of matrix.distro with matrix.os in the generated tags. e.g. humble->jammy
+          TAG="${TAG//${{ matrix.distro }}/${{ matrix.os }}}"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/Dockerfile
           build-args: |
-            TAG=${{ steps.meta.outputs.version }}
+            TAG=${{ env.TAG }}
             ROS_DISTRO=${{ matrix.distro }}
           push: ${{ env.PUSH_DOCKER_IMAGE }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set TAG environment variable based on metadata output
         run: |
           # All prior tesseract packages are on an OS level, being a ROS package, this is on a ROS distro level
-          TAG="${{ steps.meta.outputs.tags }}"
+          TAG="${{ steps.meta.outputs.version }}"
           # Replace all occurrences of matrix.distro with matrix.os in the generated tags. e.g. humble->jammy
           TAG="${TAG//${{ matrix.distro }}/${{ matrix.os }}}"
           # Export TAG to the environment variable for use in subsequent steps

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,8 +54,8 @@ jobs:
             prefix=
             suffix=
           tags: |
-            type=ref,event=branch,prefix=${{ matrix.distro }}-
-            type=ref,event=pr,prefix=${{ matrix.distro }}-
+            type=ref,event=branch,prefix=${{ matrix.distro }}-,value=${{ env.BRANCH_NAME }}
+            type=raw,event=pr,prefix=${{ matrix.distro }}-,value=master
             type=semver,pattern={{major}}.{{minor}},prefix=${{ matrix.distro }}-
 
       - name: Build and push Docker image


### PR DESCRIPTION
The current {DISTRO}-master dockers are pointing to tesseract_planning {OS}-0.21. This means they don't have the latest changes in tesseract or tesseract_planning. This change makes tesseract_ros2 consistent with tesseract_planning as seen here: https://github.com/tesseract-robotics/tesseract_planning/blob/f22b04dcbe14afe425c63d8bfbb4d14ee4255bcf/.github/workflows/docker.yml#L60 