### PR TITLE
Clean up QoS settings

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -26,5 +26,6 @@ jobs:
           if [ $? -ge 1 ]; then return 1; fi
           ./.run-clang-format
           if [ $? -ge 1 ]; then return 1; fi
+          git diff
           output=$(git diff)
           if [ -n "$output" ]; then exit 1; else exit 0; fi

--- a/tesseract_monitoring/src/contact_monitor.cpp
+++ b/tesseract_monitoring/src/contact_monitor.cpp
@@ -75,7 +75,7 @@ ContactMonitor::ContactMonitor(std::string monitor_namespace,
 
   joint_states_sub_ = internal_node_->create_subscription<sensor_msgs::msg::JointState>(
       joint_state_topic,
-      rclcpp::SensorDataQoS(),
+      rclcpp::QoS(20),
       std::bind(&ContactMonitor::callbackJointState, this, std::placeholders::_1));  // NOLINT
   std::string contact_results_topic = R"(/)" + monitor_namespace_ + DEFAULT_PUBLISH_CONTACT_RESULTS_TOPIC;
   std::string compute_contact_results = R"(/)" + monitor_namespace_ + DEFAULT_COMPUTE_CONTACT_RESULTS_SERVICE;

--- a/tesseract_monitoring/src/contact_monitor.cpp
+++ b/tesseract_monitoring/src/contact_monitor.cpp
@@ -74,7 +74,9 @@ ContactMonitor::ContactMonitor(std::string monitor_namespace,
   std::cout << ((disabled_link_names_.empty()) ? "Empty" : "Not Empty") << std::endl;
 
   joint_states_sub_ = internal_node_->create_subscription<sensor_msgs::msg::JointState>(
-      joint_state_topic, 1000, std::bind(&ContactMonitor::callbackJointState, this, std::placeholders::_1));  // NOLINT
+      joint_state_topic,
+      rclcpp::SensorDataQoS(),
+      std::bind(&ContactMonitor::callbackJointState, this, std::placeholders::_1));  // NOLINT
   std::string contact_results_topic = R"(/)" + monitor_namespace_ + DEFAULT_PUBLISH_CONTACT_RESULTS_TOPIC;
   std::string compute_contact_results = R"(/)" + monitor_namespace_ + DEFAULT_COMPUTE_CONTACT_RESULTS_SERVICE;
 
@@ -87,7 +89,7 @@ ContactMonitor::ContactMonitor(std::string monitor_namespace,
           this,
           std::placeholders::_1,
           std::placeholders::_2),
-      rmw_qos_profile_services_default);
+      rclcpp::ServicesQoS());
 }
 
 ContactMonitor::~ContactMonitor() { current_joint_states_evt_.notify_all(); }

--- a/tesseract_monitoring/src/contact_monitor.cpp
+++ b/tesseract_monitoring/src/contact_monitor.cpp
@@ -89,7 +89,11 @@ ContactMonitor::ContactMonitor(std::string monitor_namespace,
           this,
           std::placeholders::_1,
           std::placeholders::_2),
+#if RCLCPP_VERSION_GTE(28, 0, 0)
       rclcpp::ServicesQoS());
+#else
+      rmw_qos_profile_services_default);
+#endif
 }
 
 ContactMonitor::~ContactMonitor() { current_joint_states_evt_.notify_all(); }

--- a/tesseract_monitoring/src/current_state_monitor.cpp
+++ b/tesseract_monitoring/src/current_state_monitor.cpp
@@ -121,7 +121,7 @@ void CurrentStateMonitor::startStateMonitor(const std::string& joint_states_topi
     {
       joint_state_subscriber_ = node_->create_subscription<sensor_msgs::msg::JointState>(
           joint_states_topic,
-          rclcpp::SensorDataQoS(),
+          rclcpp::QoS(20),
           std::bind(&CurrentStateMonitor::jointStateCallback, this, std::placeholders::_1));  // NOLINT
     }
     state_monitor_started_ = true;

--- a/tesseract_monitoring/src/environment_monitor.cpp
+++ b/tesseract_monitoring/src/environment_monitor.cpp
@@ -215,25 +215,25 @@ bool ROSEnvironmentMonitor::initialize()
   modify_environment_service_ = internal_node_->create_service<tesseract_msgs::srv::ModifyEnvironment>(
       modify_environment_service,
       std::bind(&ROSEnvironmentMonitor::modifyEnvironmentCallback, this, _ph1, _ph2),  // NOLINT
-      rmw_qos_profile_services_default,
+      rclcpp::ServicesQoS(),
       cb_group_);
 
   get_environment_changes_service_ = internal_node_->create_service<tesseract_msgs::srv::GetEnvironmentChanges>(
       get_environment_changes_service,
       std::bind(&ROSEnvironmentMonitor::getEnvironmentChangesCallback, this, _ph1, _ph2),  // NOLINT
-      rmw_qos_profile_services_default,
+      rclcpp::ServicesQoS(),
       cb_group_);
 
   get_environment_information_service_ = internal_node_->create_service<tesseract_msgs::srv::GetEnvironmentInformation>(
       get_environment_information_service,
       std::bind(&ROSEnvironmentMonitor::getEnvironmentInformationCallback, this, _ph1, _ph2),  // NOLINT
-      rmw_qos_profile_services_default,
+      rclcpp::ServicesQoS(),
       cb_group_);
 
   save_scene_graph_service_ = internal_node_->create_service<tesseract_msgs::srv::SaveSceneGraph>(
       save_scene_graph_service,
       std::bind(&ROSEnvironmentMonitor::saveSceneGraphCallback, this, _ph1, _ph2),  // NOLINT
-      rmw_qos_profile_services_default,
+      rclcpp::ServicesQoS(),
       cb_group_);
 
   return true;
@@ -349,16 +349,16 @@ void ROSEnvironmentMonitor::startMonitoringEnvironment(const std::string& monito
   stopMonitoringEnvironment();
 
   get_monitored_environment_changes_client_ = internal_node_->create_client<tesseract_msgs::srv::GetEnvironmentChanges>(
-      monitored_environment_changes_service, rmw_qos_profile_services_default, cb_group_);
+      monitored_environment_changes_service, rclcpp::ServicesQoS(), cb_group_);
   modify_monitored_environment_client_ = internal_node_->create_client<tesseract_msgs::srv::ModifyEnvironment>(
-      monitored_environment_modify_service, rmw_qos_profile_services_default, cb_group_);
+      monitored_environment_modify_service, rclcpp::ServicesQoS(), cb_group_);
   get_monitored_environment_information_client_ =
       internal_node_->create_client<tesseract_msgs::srv::GetEnvironmentInformation>(
-          monitored_environment_information_service, rmw_qos_profile_services_default, cb_group_);
+          monitored_environment_information_service, rclcpp::ServicesQoS(), cb_group_);
 
   monitored_environment_subscriber_ = internal_node_->create_subscription<tesseract_msgs::msg::EnvironmentState>(
       monitored_environment_topic,
-      1000,
+      rclcpp::ParameterEventsQoS(),
       std::bind(&ROSEnvironmentMonitor::newEnvironmentStateCallback, this, std::placeholders::_1));  // NOLINT
 
   RCLCPP_INFO(logger_, "Monitoring external environment on '%s'", monitored_environment_topic.c_str());

--- a/tesseract_monitoring/src/environment_monitor.cpp
+++ b/tesseract_monitoring/src/environment_monitor.cpp
@@ -215,25 +215,41 @@ bool ROSEnvironmentMonitor::initialize()
   modify_environment_service_ = internal_node_->create_service<tesseract_msgs::srv::ModifyEnvironment>(
       modify_environment_service,
       std::bind(&ROSEnvironmentMonitor::modifyEnvironmentCallback, this, _ph1, _ph2),  // NOLINT
+#if RCLCPP_VERSION_GTE(28, 0, 0)
       rclcpp::ServicesQoS(),
+#else
+      rmw_qos_profile_services_default,
+#endif
       cb_group_);
 
   get_environment_changes_service_ = internal_node_->create_service<tesseract_msgs::srv::GetEnvironmentChanges>(
       get_environment_changes_service,
       std::bind(&ROSEnvironmentMonitor::getEnvironmentChangesCallback, this, _ph1, _ph2),  // NOLINT
+#if RCLCPP_VERSION_GTE(28, 0, 0)
       rclcpp::ServicesQoS(),
+#else
+      rmw_qos_profile_services_default,
+#endif
       cb_group_);
 
   get_environment_information_service_ = internal_node_->create_service<tesseract_msgs::srv::GetEnvironmentInformation>(
       get_environment_information_service,
       std::bind(&ROSEnvironmentMonitor::getEnvironmentInformationCallback, this, _ph1, _ph2),  // NOLINT
+#if RCLCPP_VERSION_GTE(28, 0, 0)
       rclcpp::ServicesQoS(),
+#else
+      rmw_qos_profile_services_default,
+#endif
       cb_group_);
 
   save_scene_graph_service_ = internal_node_->create_service<tesseract_msgs::srv::SaveSceneGraph>(
       save_scene_graph_service,
       std::bind(&ROSEnvironmentMonitor::saveSceneGraphCallback, this, _ph1, _ph2),  // NOLINT
+#if RCLCPP_VERSION_GTE(28, 0, 0)
       rclcpp::ServicesQoS(),
+#else
+      rmw_qos_profile_services_default,
+#endif
       cb_group_);
 
   return true;
@@ -348,13 +364,31 @@ void ROSEnvironmentMonitor::startMonitoringEnvironment(const std::string& monito
 
   stopMonitoringEnvironment();
 
-  get_monitored_environment_changes_client_ = internal_node_->create_client<tesseract_msgs::srv::GetEnvironmentChanges>(
-      monitored_environment_changes_service, rclcpp::ServicesQoS(), cb_group_);
-  modify_monitored_environment_client_ = internal_node_->create_client<tesseract_msgs::srv::ModifyEnvironment>(
-      monitored_environment_modify_service, rclcpp::ServicesQoS(), cb_group_);
+  get_monitored_environment_changes_client_ =
+      internal_node_->create_client<tesseract_msgs::srv::GetEnvironmentChanges>(monitored_environment_changes_service,
+#if RCLCPP_VERSION_GTE(28, 0, 0)
+                                                                                rclcpp::ServicesQoS(),
+#else
+                                                                                rmw_qos_profile_services_default,
+#endif
+                                                                                cb_group_);
+  modify_monitored_environment_client_ =
+      internal_node_->create_client<tesseract_msgs::srv::ModifyEnvironment>(monitored_environment_modify_service,
+#if RCLCPP_VERSION_GTE(28, 0, 0)
+                                                                            rclcpp::ServicesQoS(),
+#else
+                                                                            rmw_qos_profile_services_default,
+#endif
+                                                                            cb_group_);
   get_monitored_environment_information_client_ =
       internal_node_->create_client<tesseract_msgs::srv::GetEnvironmentInformation>(
-          monitored_environment_information_service, rclcpp::ServicesQoS(), cb_group_);
+          monitored_environment_information_service,
+#if RCLCPP_VERSION_GTE(28, 0, 0)
+          rclcpp::ServicesQoS(),
+#else
+          rmw_qos_profile_services_default,
+#endif
+          cb_group_);
 
   monitored_environment_subscriber_ = internal_node_->create_subscription<tesseract_msgs::msg::EnvironmentState>(
       monitored_environment_topic,

--- a/tesseract_monitoring/src/environment_monitor_interface.cpp
+++ b/tesseract_monitoring/src/environment_monitor_interface.cpp
@@ -50,7 +50,7 @@ typename SrvType::Response::SharedPtr call_service(const std::string& name,
                                                    rclcpp::CallbackGroup::SharedPtr cbg,
                                                    std::chrono::duration<double> timeout)
 {
-  auto client = node.create_client<SrvType>(name, ::rmw_qos_profile_services_default, cbg);
+  auto client = node.create_client<SrvType>(name, rclcpp::ServicesQoS(), cbg);
   if (!client->service_is_ready())
   {
     RCLCPP_ERROR_STREAM(node.get_logger(), "Service '" << name << "' not available!");

--- a/tesseract_monitoring/src/environment_monitor_interface.cpp
+++ b/tesseract_monitoring/src/environment_monitor_interface.cpp
@@ -85,14 +85,17 @@ ROSEnvironmentMonitorInterface::ROSEnvironmentMonitorInterface(rclcpp::Node::Sha
   : EnvironmentMonitorInterface(std::move(env_name))
   , node_(std::move(node))
 #if RCLCPP_VERSION_GTE(16, 0, 0)  // ROS 2 Humble
-  , callback_group_{ node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false) }
-#else  // ROS 2 Foxy
-  , callback_group_{ node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive) }
-#endif
-  , logger_{ node_->get_logger().get_child(env_name + "_env_monitor") }
-  , env_name_{ env_name }
+  , callback_group_
 {
+  node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false)
 }
+#else  // ROS 2 Foxy
+  , callback_group_
+{
+  node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive)
+}
+#endif
+, logger_{ node_->get_logger().get_child(env_name + "_env_monitor") }, env_name_{ env_name } {}
 
 bool ROSEnvironmentMonitorInterface::wait(std::chrono::duration<double> duration) const
 {

--- a/tesseract_ros_examples/src/online_planning_example_node.cpp
+++ b/tesseract_ros_examples/src/online_planning_example_node.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
 
   // Set up ROS interfaces
   auto joint_state_subscriber_ =
-      node->create_subscription<sensor_msgs::msg::JointState>(DYNAMIC_OBJECT_JOINT_STATE, rclcpp::QoS(25), fn2);
+      node->create_subscription<sensor_msgs::msg::JointState>(DYNAMIC_OBJECT_JOINT_STATE, rclcpp::SensorDataQoS(), fn2);
 
   auto toggle_realtime_service = node->create_service<std_srvs::srv::SetBool>("toggle_realtime", fn1);
 

--- a/tesseract_ros_examples/src/online_planning_example_node.cpp
+++ b/tesseract_ros_examples/src/online_planning_example_node.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
 
   // Set up ROS interfaces
   auto joint_state_subscriber_ =
-      node->create_subscription<sensor_msgs::msg::JointState>(DYNAMIC_OBJECT_JOINT_STATE, rclcpp::SensorDataQoS(), fn2);
+      node->create_subscription<sensor_msgs::msg::JointState>(DYNAMIC_OBJECT_JOINT_STATE, rclcpp::QoS(20), fn2);
 
   auto toggle_realtime_service = node->create_service<std_srvs::srv::SetBool>("toggle_realtime", fn1);
 

--- a/tesseract_rosutils/include/tesseract_rosutils/utils.h
+++ b/tesseract_rosutils/include/tesseract_rosutils/utils.h
@@ -64,6 +64,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
+#if __has_include(<rclcpp/version.h>)
+#include <rclcpp/version.h>
+#endif
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/serialization.hpp>
 #include <boost/serialization/access.hpp>
@@ -87,6 +90,11 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_srdf/kinematics_information.h>  // For all the nested using
 #include <tesseract_collision/core/types.h>         // For all the nested using
+
+// Define rclcpp version macro for older ROS2 versions without <rclcpp/version.h>
+#ifndef RCLCPP_VERSION_GTE
+#define RCLCPP_VERSION_GTE(major, minor, patch) false
+#endif
 
 namespace tesseract_rosutils
 {

--- a/tesseract_rosutils/src/plotting.cpp
+++ b/tesseract_rosutils/src/plotting.cpp
@@ -57,20 +57,20 @@ ROSPlotting::ROSPlotting(std::string root_link, std::string topic_namespace)
   trajectory_pub_ = internal_node_->create_publisher<tesseract_msgs::msg::Trajectory>(topic_namespace_ + "/display_"
                                                                                                          "tesseract_"
                                                                                                          "trajectory",
-                                                                                      rclcpp::QoS(100));
+                                                                                      rclcpp::QoS(20));
   collisions_pub_ = internal_node_->create_publisher<visualization_msgs::msg::MarkerArray>(topic_namespace_ + "/display"
                                                                                                               "_collisi"
                                                                                                               "ons",
-                                                                                           rclcpp::QoS(100));
+                                                                                           rclcpp::QoS(20));
   arrows_pub_ = internal_node_->create_publisher<visualization_msgs::msg::MarkerArray>(topic_namespace_ + "/display_"
                                                                                                           "arrows",
-                                                                                       rclcpp::QoS(100));
+                                                                                       rclcpp::QoS(20));
   axes_pub_ = internal_node_->create_publisher<visualization_msgs::msg::MarkerArray>(topic_namespace_ + "/display_axes",
-                                                                                     rclcpp::QoS(100));
+                                                                                     rclcpp::QoS(20));
   tool_path_pub_ = internal_node_->create_publisher<visualization_msgs::msg::MarkerArray>(topic_namespace_ + "/display_"
                                                                                                              "tool_"
                                                                                                              "path",
-                                                                                          rclcpp::QoS(100));
+                                                                                          rclcpp::QoS(20));
 
   internal_node_executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
   internal_node_spinner_ = std::make_shared<std::thread>([this]() {

--- a/tesseract_rosutils/src/plotting.cpp
+++ b/tesseract_rosutils/src/plotting.cpp
@@ -57,19 +57,20 @@ ROSPlotting::ROSPlotting(std::string root_link, std::string topic_namespace)
   trajectory_pub_ = internal_node_->create_publisher<tesseract_msgs::msg::Trajectory>(topic_namespace_ + "/display_"
                                                                                                          "tesseract_"
                                                                                                          "trajectory",
-                                                                                      1);
+                                                                                      rclcpp::QoS(100));
   collisions_pub_ = internal_node_->create_publisher<visualization_msgs::msg::MarkerArray>(topic_namespace_ + "/display"
                                                                                                               "_collisi"
                                                                                                               "ons",
-                                                                                           1);
-  arrows_pub_ =
-      internal_node_->create_publisher<visualization_msgs::msg::MarkerArray>(topic_namespace_ + "/display_arrows", 1);
-  axes_pub_ =
-      internal_node_->create_publisher<visualization_msgs::msg::MarkerArray>(topic_namespace_ + "/display_axes", 1);
+                                                                                           rclcpp::QoS(100));
+  arrows_pub_ = internal_node_->create_publisher<visualization_msgs::msg::MarkerArray>(topic_namespace_ + "/display_"
+                                                                                                          "arrows",
+                                                                                       rclcpp::QoS(100));
+  axes_pub_ = internal_node_->create_publisher<visualization_msgs::msg::MarkerArray>(topic_namespace_ + "/display_axes",
+                                                                                     rclcpp::QoS(100));
   tool_path_pub_ = internal_node_->create_publisher<visualization_msgs::msg::MarkerArray>(topic_namespace_ + "/display_"
                                                                                                              "tool_"
                                                                                                              "path",
-                                                                                          1);
+                                                                                          rclcpp::QoS(100));
 
   internal_node_executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
   internal_node_spinner_ = std::make_shared<std::thread>([this]() {

--- a/tesseract_rviz/src/environment_monitor_properties.cpp
+++ b/tesseract_rviz/src/environment_monitor_properties.cpp
@@ -334,7 +334,7 @@ void EnvironmentMonitorProperties::onEnvironmentSnapshotTopicChanged()
   // Connect to new topic
   data_->snapshot = data_->node->create_subscription<tesseract_msgs::msg::Environment>(
       data_->environment_snapshot_topic_property->getTopicStd(),
-      10,
+      rclcpp::ServicesQoS(),
       std::bind(&EnvironmentMonitorProperties::snapshotCallback, this, std::placeholders::_1));
 }
 

--- a/tesseract_rviz/src/environment_monitor_properties.cpp
+++ b/tesseract_rviz/src/environment_monitor_properties.cpp
@@ -334,7 +334,11 @@ void EnvironmentMonitorProperties::onEnvironmentSnapshotTopicChanged()
   // Connect to new topic
   data_->snapshot = data_->node->create_subscription<tesseract_msgs::msg::Environment>(
       data_->environment_snapshot_topic_property->getTopicStd(),
+#if RCLCPP_VERSION_GTE(28, 0, 0)
       rclcpp::ServicesQoS(),
+#else
+      rmw_qos_profile_services_default,
+#endif
       std::bind(&EnvironmentMonitorProperties::snapshotCallback, this, std::placeholders::_1));
 }
 

--- a/tesseract_rviz/src/environment_monitor_properties.cpp
+++ b/tesseract_rviz/src/environment_monitor_properties.cpp
@@ -334,11 +334,7 @@ void EnvironmentMonitorProperties::onEnvironmentSnapshotTopicChanged()
   // Connect to new topic
   data_->snapshot = data_->node->create_subscription<tesseract_msgs::msg::Environment>(
       data_->environment_snapshot_topic_property->getTopicStd(),
-#if RCLCPP_VERSION_GTE(28, 0, 0)
       rclcpp::ServicesQoS(),
-#else
-      rmw_qos_profile_services_default,
-#endif
       std::bind(&EnvironmentMonitorProperties::snapshotCallback, this, std::placeholders::_1));
 }
 

--- a/tesseract_rviz/src/joint_trajectory_monitor_properties.cpp
+++ b/tesseract_rviz/src/joint_trajectory_monitor_properties.cpp
@@ -228,7 +228,7 @@ void JointTrajectoryMonitorProperties::onLegacyJointTrajectoryTopicConnect()
 {
   data_->legacy_joint_trajectory_sub = data_->node->create_subscription<trajectory_msgs::msg::JointTrajectory>(
       data_->legacy_joint_trajectory_topic_property->getStdString(),
-      rclcpp::SensorDataQoS(),
+      rclcpp::QoS(20),
       std::bind(&JointTrajectoryMonitorProperties::Implementation::legacyJointTrajectoryCallback,
                 *data_,
                 std::placeholders::_1));
@@ -238,7 +238,7 @@ void JointTrajectoryMonitorProperties::onTesseractJointTrajectoryTopicConnect()
 {
   data_->tesseract_joint_trajectory_sub = data_->node->create_subscription<tesseract_msgs::msg::Trajectory>(
       data_->tesseract_joint_trajectory_topic_property->getStdString(),
-      rclcpp::SensorDataQoS(),
+      rclcpp::QoS(20),
       std::bind(&JointTrajectoryMonitorProperties::Implementation::tesseractJointTrajectoryCallback,
                 *data_,
                 std::placeholders::_1));

--- a/tesseract_rviz/src/joint_trajectory_monitor_properties.cpp
+++ b/tesseract_rviz/src/joint_trajectory_monitor_properties.cpp
@@ -228,7 +228,7 @@ void JointTrajectoryMonitorProperties::onLegacyJointTrajectoryTopicConnect()
 {
   data_->legacy_joint_trajectory_sub = data_->node->create_subscription<trajectory_msgs::msg::JointTrajectory>(
       data_->legacy_joint_trajectory_topic_property->getStdString(),
-      20,
+      rclcpp::SensorDataQoS(),
       std::bind(&JointTrajectoryMonitorProperties::Implementation::legacyJointTrajectoryCallback,
                 *data_,
                 std::placeholders::_1));
@@ -238,7 +238,7 @@ void JointTrajectoryMonitorProperties::onTesseractJointTrajectoryTopicConnect()
 {
   data_->tesseract_joint_trajectory_sub = data_->node->create_subscription<tesseract_msgs::msg::Trajectory>(
       data_->tesseract_joint_trajectory_topic_property->getStdString(),
-      20,
+      rclcpp::SensorDataQoS(),
       std::bind(&JointTrajectoryMonitorProperties::Implementation::tesseractJointTrajectoryCallback,
                 *data_,
                 std::placeholders::_1));


### PR DESCRIPTION
- Replace deprecated rmw_qos_profile_* profiles by their newer rclcpp counterparts. 
- Use SensorDataQoS() for joint state subscriptions.
- Increase history depth for plotting (with a history of 1, the Workbench missed planning results when sent too quickly).
- Some other replacements to defaults or matching profiles.