### PR TITLE
Generate unique node name for ROSPlotting

### DIFF
--- a/tesseract_rosutils/src/plotting.cpp
+++ b/tesseract_rosutils/src/plotting.cpp
@@ -53,7 +53,10 @@ static constexpr const char* NODE_ID = "tesseract_rosutils_plotting";
 ROSPlotting::ROSPlotting(std::string root_link, std::string topic_namespace)
   : root_link_(std::move(root_link)), topic_namespace_(std::move(topic_namespace))
 {
-  internal_node_ = std::make_shared<rclcpp::Node>(NODE_ID);
+  // Create a unique name for the node
+  char node_name[45];                                                                         // NOLINT
+  snprintf(node_name, sizeof(node_name), "%s_%zx", NODE_ID, reinterpret_cast<size_t>(this));  // NOLINT
+  internal_node_ = std::make_shared<rclcpp::Node>(node_name);
   trajectory_pub_ = internal_node_->create_publisher<tesseract_msgs::msg::Trajectory>(topic_namespace_ + "/display_"
                                                                                                          "tesseract_"
                                                                                                          "trajectory",


### PR DESCRIPTION
This fixes the duplicate node name problem if multiple instances of ROSPlotting are used (`ros2 node list` says "WARNING: Be aware that there are nodes in the graph that share an exact name, which can have unintended side effects.").

The 'side effect' for me was lost trajectory messages, which seems to be fixed now.

Inspiration [taken from tf2](https://github.com/ros2/geometry2/blob/jazzy/tf2_ros/src/transform_listener.cpp#L52).