### PR TITLE
Remove TransformBroadcaster from CurrentStateMonitor

### DIFF
--- a/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
+++ b/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
@@ -93,11 +93,8 @@ public:
 
   /** @brief Start monitoring joint states on a particular topic
    *  @param joint_states_topic The topic name for joint states (defaults to "joint_states")
-   *  @param publish_tf If true, TFs will be published for each joint (similar to robot description publisher). Default:
-   * true
    */
-  void startStateMonitor(const std::string& joint_states_topic = tesseract_monitoring::DEFAULT_JOINT_STATES_TOPIC,
-                         bool publish_tf = true);
+  void startStateMonitor(const std::string& joint_states_topic = tesseract_monitoring::DEFAULT_JOINT_STATES_TOPIC);
 
   /** @brief Stop monitoring the "joint_states" topic
    */
@@ -202,10 +199,8 @@ private:
   double error_;
 
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_subscriber_;
-  tf2_ros::TransformBroadcaster tf_broadcaster_;
   rclcpp::Time current_state_time_;
   rclcpp::Time last_tf_update_;
-  bool publish_tf_;
 
   mutable std::mutex state_update_lock_;
   mutable std::condition_variable state_update_condition_;

--- a/tesseract_monitoring/include/tesseract_monitoring/environment_monitor.h
+++ b/tesseract_monitoring/include/tesseract_monitoring/environment_monitor.h
@@ -129,8 +129,7 @@ public:
 
   double getEnvironmentPublishingFrequency() const override final;
 
-  void startStateMonitor(const std::string& joint_states_topic = DEFAULT_JOINT_STATES_TOPIC,
-                         bool publish_tf = true) override final;
+  void startStateMonitor(const std::string& joint_states_topic = DEFAULT_JOINT_STATES_TOPIC) override final;
 
   void stopStateMonitor() override final;
 

--- a/tesseract_monitoring/src/environment_monitor.cpp
+++ b/tesseract_monitoring/src/environment_monitor.cpp
@@ -694,7 +694,7 @@ bool ROSEnvironmentMonitor::waitForCurrentState(std::chrono::duration<double> du
   return success;
 }
 
-void ROSEnvironmentMonitor::startStateMonitor(const std::string& joint_states_topic, bool publish_tf)
+void ROSEnvironmentMonitor::startStateMonitor(const std::string& joint_states_topic)
 {
   stopStateMonitor();
   if (env_)
@@ -704,7 +704,7 @@ void ROSEnvironmentMonitor::startStateMonitor(const std::string& joint_states_to
 
     current_state_monitor_->addUpdateCallback(
         std::bind(&ROSEnvironmentMonitor::onJointStateUpdate, this, std::placeholders::_1));  // NOLINT
-    current_state_monitor_->startStateMonitor(joint_states_topic, publish_tf);
+    current_state_monitor_->startStateMonitor(joint_states_topic);
 
     {
       std::scoped_lock lock(state_pending_mutex_);

--- a/tesseract_monitoring/src/environment_monitor_node.cpp
+++ b/tesseract_monitoring/src/environment_monitor_node.cpp
@@ -49,11 +49,10 @@ int main(int argc, char** argv)
   if (!monitored_namespace.empty())
     monitor.startMonitoringEnvironment(monitored_namespace);
 
-  bool publish_tf = monitored_namespace.empty();
   if (joint_state_topic.empty())
-    monitor.startStateMonitor(DEFAULT_JOINT_STATES_TOPIC, publish_tf);
+    monitor.startStateMonitor(DEFAULT_JOINT_STATES_TOPIC);
   else
-    monitor.startStateMonitor(joint_state_topic, publish_tf);
+    monitor.startStateMonitor(joint_state_topic);
 
   RCLCPP_INFO(node->get_logger(), "Environment Monitor Running!");
 

--- a/tesseract_qt_ros/src/widgets/environment_monitor_widget.cpp
+++ b/tesseract_qt_ros/src/widgets/environment_monitor_widget.cpp
@@ -310,7 +310,7 @@ void EnvironmentMonitorWidget::onJointStateTopicChanged()
     return;
 
   if (data_->monitor != nullptr)
-    data_->monitor->startStateMonitor(ui->joint_state_topic_combo_box->currentText().toStdString(), false);
+    data_->monitor->startStateMonitor(ui->joint_state_topic_combo_box->currentText().toStdString());
 }
 
 void EnvironmentMonitorWidget::onStatus(bool connected)

--- a/tesseract_rviz/src/environment_monitor_properties.cpp
+++ b/tesseract_rviz/src/environment_monitor_properties.cpp
@@ -365,7 +365,7 @@ void EnvironmentMonitorProperties::onJointStateTopicChanged()
     return;
 
   if (data_->monitor != nullptr)
-    data_->monitor->startStateMonitor(data_->joint_state_topic_property->getTopicStd(), false);
+    data_->monitor->startStateMonitor(data_->joint_state_topic_property->getTopicStd());
 }
 
 }  // namespace tesseract_rviz


### PR DESCRIPTION
This removes the TransformBroadcaster from the CurrentStateMonitor.

Reasons:
- Currently, the published transforms are not a proper tree as would be expected, but all transforms originate from the root link. This is not very useful.
- All transforms are published to /tf, instead of separately publishing dynamic and static links to /tf and /tf_static like the robot_state_publisher does.
- The current_state_monitor of MoveIt 1, from which this monitor is derived, does not publish the tf tree either.
