### PR TITLE
Remove TransformBroadcaster from CurrentStateMonitor and reintroduce in ROSEnvironmentMonitor

### DIFF
--- a/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
+++ b/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
@@ -47,7 +47,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <functional>
 #include <unordered_map>
 #include <map>
-#include <tf2_ros/transform_broadcaster.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_monitoring/constants.h>
@@ -93,11 +92,8 @@ public:
 
   /** @brief Start monitoring joint states on a particular topic
    *  @param joint_states_topic The topic name for joint states (defaults to "joint_states")
-   *  @param publish_tf If true, TFs will be published for each joint (similar to robot description publisher). Default:
-   * true
    */
-  void startStateMonitor(const std::string& joint_states_topic = tesseract_monitoring::DEFAULT_JOINT_STATES_TOPIC,
-                         bool publish_tf = true);
+  void startStateMonitor(const std::string& joint_states_topic = tesseract_monitoring::DEFAULT_JOINT_STATES_TOPIC);
 
   /** @brief Stop monitoring the "joint_states" topic
    */
@@ -202,10 +198,7 @@ private:
   double error_;
 
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_subscriber_;
-  tf2_ros::TransformBroadcaster tf_broadcaster_;
   rclcpp::Time current_state_time_;
-  rclcpp::Time last_tf_update_;
-  bool publish_tf_;
 
   mutable std::mutex state_update_lock_;
   mutable std::condition_variable state_update_condition_;

--- a/tesseract_monitoring/include/tesseract_monitoring/environment_monitor.h
+++ b/tesseract_monitoring/include/tesseract_monitoring/environment_monitor.h
@@ -39,11 +39,15 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <rclcpp/rclcpp.hpp>
 #include <memory>
 #include <mutex>
 #include <thread>
 #include <functional>
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+
 #include <tesseract_msgs/msg/environment_state.hpp>
 #include <tesseract_msgs/srv/modify_environment.hpp>
 #include <tesseract_msgs/srv/get_environment_changes.hpp>
@@ -123,12 +127,15 @@ public:
 
   void startPublishingEnvironment() override final;
 
+  void startPublishingEnvironment(bool publish_tf);
+
   void stopPublishingEnvironment() override final;
 
   void setEnvironmentPublishingFrequency(double hz) override final;
 
   double getEnvironmentPublishingFrequency() const override final;
 
+  // TODO: publish_tf does nothing anymore, remove from signature in tesseract_environment::EnvironmentMonitor
   void startStateMonitor(const std::string& joint_states_topic = DEFAULT_JOINT_STATES_TOPIC,
                          bool publish_tf = true) override final;
 
@@ -174,6 +181,9 @@ protected:
   rclcpp::Publisher<tesseract_msgs::msg::EnvironmentState>::SharedPtr environment_publisher_;
   std::unique_ptr<std::thread> publish_environment_;
   double publish_environment_frequency_{ 30.0 };
+  std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+  std::unique_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
+  bool publish_tf_{};
 
   // variables for monitored environment
   rclcpp::Subscription<tesseract_msgs::msg::EnvironmentState>::SharedPtr monitored_environment_subscriber_;

--- a/tesseract_monitoring/src/current_state_monitor.cpp
+++ b/tesseract_monitoring/src/current_state_monitor.cpp
@@ -67,8 +67,6 @@ CurrentStateMonitor::CurrentStateMonitor(const tesseract_environment::Environmen
   , state_monitor_started_(false)
   , copy_dynamics_(false)
   , error_(std::numeric_limits<double>::epsilon())
-  , tf_broadcaster_(node_)
-  , publish_tf_(true)
 {
 }
 
@@ -107,23 +105,23 @@ void CurrentStateMonitor::addUpdateCallback(const JointStateUpdateCallback& fn)
 }
 
 void CurrentStateMonitor::clearUpdateCallbacks() { update_callbacks_.clear(); }
-void CurrentStateMonitor::startStateMonitor(const std::string& joint_states_topic, bool publish_tf)
+
+void CurrentStateMonitor::startStateMonitor(const std::string& joint_states_topic)
 {
-  publish_tf_ = publish_tf;
   if (!state_monitor_started_ && env_)
   {
     joint_time_.clear();
     if (joint_states_topic.empty())
     {
       RCLCPP_ERROR(node_->get_logger(), "The joint states topic cannot be an empty string");
+      return;
     }
-    else
-    {
-      joint_state_subscriber_ = node_->create_subscription<sensor_msgs::msg::JointState>(
-          joint_states_topic,
-          rclcpp::QoS(20),
-          std::bind(&CurrentStateMonitor::jointStateCallback, this, std::placeholders::_1));  // NOLINT
-    }
+
+    joint_state_subscriber_ = node_->create_subscription<sensor_msgs::msg::JointState>(
+        joint_states_topic,
+        rclcpp::QoS(20),
+        std::bind(&CurrentStateMonitor::jointStateCallback, this, std::placeholders::_1));  // NOLINT
+
     state_monitor_started_ = true;
     monitor_start_time_ = node_->now();
     RCLCPP_DEBUG(node_->get_logger(), "Listening to joint states on topic '%s'", joint_states_topic.c_str());
@@ -353,25 +351,6 @@ void CurrentStateMonitor::jointStateCallback(const sensor_msgs::msg::JointState:
 
     if (update)
       env_state_ = env_->getState(env_state_.joints);
-
-    if (publish_tf_)
-    {
-      std::string base_link = env_->getRootLinkName();
-      std::vector<geometry_msgs::msg::TransformStamped> transforms;
-      transforms.reserve(env_state_.joints.size());
-      for (const auto& pose : env_state_.link_transforms)
-      {
-        if (pose.first != base_link)
-        {
-          geometry_msgs::msg::TransformStamped tf = tf2::eigenToTransform(pose.second);
-          tf.header.stamp = current_state_time_;
-          tf.header.frame_id = base_link;
-          tf.child_frame_id = pose.first;
-          transforms.push_back(tf);
-        }
-      }
-      tf_broadcaster_.sendTransform(transforms);
-    }
   }
 
   // callbacks, if needed

--- a/tesseract_monitoring/src/environment_monitor_node.cpp
+++ b/tesseract_monitoring/src/environment_monitor_node.cpp
@@ -43,17 +43,17 @@ int main(int argc, char** argv)
 
   tesseract_monitoring::ROSEnvironmentMonitor monitor(node, ROBOT_DESCRIPTION_PARAM, monitor_namespace);
 
+  bool publish_tf = monitored_namespace.empty();
   if (publish_environment)
-    monitor.startPublishingEnvironment();
+    monitor.startPublishingEnvironment(publish_tf);
 
   if (!monitored_namespace.empty())
     monitor.startMonitoringEnvironment(monitored_namespace);
 
-  bool publish_tf = monitored_namespace.empty();
   if (joint_state_topic.empty())
-    monitor.startStateMonitor(DEFAULT_JOINT_STATES_TOPIC, publish_tf);
+    monitor.startStateMonitor(DEFAULT_JOINT_STATES_TOPIC);
   else
-    monitor.startStateMonitor(joint_state_topic, publish_tf);
+    monitor.startStateMonitor(joint_state_topic);
 
   RCLCPP_INFO(node->get_logger(), "Environment Monitor Running!");
 

--- a/tesseract_qt_ros/src/widgets/environment_monitor_widget.cpp
+++ b/tesseract_qt_ros/src/widgets/environment_monitor_widget.cpp
@@ -310,7 +310,7 @@ void EnvironmentMonitorWidget::onJointStateTopicChanged()
     return;
 
   if (data_->monitor != nullptr)
-    data_->monitor->startStateMonitor(ui->joint_state_topic_combo_box->currentText().toStdString(), false);
+    data_->monitor->startStateMonitor(ui->joint_state_topic_combo_box->currentText().toStdString());
 }
 
 void EnvironmentMonitorWidget::onStatus(bool connected)

--- a/tesseract_rosutils/include/tesseract_rosutils/utils.h
+++ b/tesseract_rosutils/include/tesseract_rosutils/utils.h
@@ -62,6 +62,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <tesseract_msgs/msg/task_composer_node_info.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
 #if __has_include(<rclcpp/version.h>)
 #include <rclcpp/version.h>
@@ -506,6 +507,18 @@ trajectory_msgs::msg::JointTrajectory toMsg(const tesseract_common::JointTraject
  * @return A tesseract joint trajectory
  */
 tesseract_common::JointTrajectory fromMsg(const trajectory_msgs::msg::JointTrajectory& joint_trajectory_msg);
+
+/**
+ * @brief Generate tf messages from the current state of the environment
+ * @param env The environment
+ * @param stamp The time stamp to apply to the transforms
+ * @param transforms The output vector of tf messages
+ * @param static_transforms The output vector of static tf messages
+ */
+void toTransformMsgs(const std::shared_ptr<tesseract_environment::Environment>& env,
+                     const rclcpp::Time& stamp,
+                     std::vector<geometry_msgs::msg::TransformStamped>& transforms,
+                     std::vector<geometry_msgs::msg::TransformStamped>& static_transforms);
 
 template <typename MessageType>
 inline bool toFile(const std::string& filepath, const MessageType& msg)

--- a/tesseract_rosutils/src/utils.cpp
+++ b/tesseract_rosutils/src/utils.cpp
@@ -2431,29 +2431,23 @@ void toTransformMsgs(const std::shared_ptr<tesseract_environment::Environment>& 
   const auto& scene_graph = env->getSceneGraph();
   const auto& active_joints = env->getActiveJointNames();
 
-  // Convert link transforms to TransformStamped messages
-  for (const auto& link_name : env->getLinkNames())
+  for (const auto& joint : scene_graph->getJoints())
   {
-    // Find the parent links for this link in the scene graph
-    for (const auto& inbound_joint : scene_graph->getInboundJoints(link_name))
-    {
-      const auto& parent_link_name = inbound_joint->parent_link_name;
-      const auto& tf = env->getRelativeLinkTransform(parent_link_name, link_name);
-      // Convert Eigen transform to geometry_msgs transform
-      auto transform_msg = tf2::eigenToTransform(tf);
-      transform_msg.header.stamp = stamp;
-      transform_msg.header.frame_id = parent_link_name;
-      transform_msg.child_frame_id = link_name;
+    const auto& tf = env->getRelativeLinkTransform(joint->parent_link_name, joint->child_link_name);
+    // Convert link transform to TransformStamped message
+    auto transform_msg = tf2::eigenToTransform(tf);
+    transform_msg.header.stamp = stamp;
+    transform_msg.header.frame_id = joint->parent_link_name;
+    transform_msg.child_frame_id = joint->child_link_name;
 
-      // Add to appropriate collection based on whether it's static (connected by a fixed joint) or dynamic
-      if ((std::find(active_joints.begin(), active_joints.end(), inbound_joint->getName()) == active_joints.end()))
-      {
-        static_transforms.push_back(transform_msg);
-      }
-      else
-      {
-        transforms.push_back(transform_msg);
-      }
+    // Add to appropriate collection based on whether it's static (connected by a fixed joint) or dynamic
+    if ((std::find(active_joints.begin(), active_joints.end(), joint->getName()) == active_joints.end()))
+    {
+      static_transforms.push_back(transform_msg);
+    }
+    else
+    {
+      transforms.push_back(transform_msg);
     }
   }
 }

--- a/tesseract_rviz/src/environment_monitor_properties.cpp
+++ b/tesseract_rviz/src/environment_monitor_properties.cpp
@@ -365,7 +365,7 @@ void EnvironmentMonitorProperties::onJointStateTopicChanged()
     return;
 
   if (data_->monitor != nullptr)
-    data_->monitor->startStateMonitor(data_->joint_state_topic_property->getTopicStd(), false);
+    data_->monitor->startStateMonitor(data_->joint_state_topic_property->getTopicStd());
 }
 
 }  // namespace tesseract_rviz


### PR DESCRIPTION
This removes the TransformBroadcaster from the CurrentStateMonitor and reintroduces it in the ROSEnvironmentMonitor.

Reasons:
- Currently, the published transforms are not a proper tree as would be expected, but all transforms originate from the root link.
- The CurrentStateMonitor only publishes the tf when a joint_state_message has been received. An environment without a CurrentStateMonitor, or without anyone publishing states to it, will therefore not publish its transform tree.
- All transforms are published to /tf, instead of separately publishing dynamic and static links to /tf and /tf_static like the robot_state_publisher does.
- The current_state_monitor of MoveIt 1, from which this monitor is derived, does not publish the tf tree either.

The transform broadcasting functionality is reintroduced in ROSEnvironmentMonitor:
- It produces a proper transform tree.
- It publishes dynamic links to /tf and static links to /tf_static.
- It can we switched on or off with a parameter to startPublishingEnvironment.
- When enabled, it publishes the transforms of the current environment even if no joint states are monitored.

This way, an almost complete replacement of the robot_state_publisher is provided.

Unlike in robot_state_publisher, however, the /robot_description topic is not published. This is because in Tesseract an environment can be modified, and there are currently no methods available to generate an updated URDF from the current environment.