### PR TITLE
Updated ROS2 install procedure based on signing key migration

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,9 +11,10 @@ USER root
 ARG ROS_DISTRO
 
 # Add the ROS sources
-RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null \
-  && apt update -qq
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') \
+  && curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+  && apt install /tmp/ros2-apt-source.deb \
+  && apt update -y -qq
 
 RUN apt install -y \
   ros-${ROS_DISTRO}-ros-base \


### PR DESCRIPTION
Changes per commit message to install ROS2 in the Docker image based on new instructions after [signing key migration ](https://discourse.ros.org/t/ros-signing-key-migration-guide/43937)