### PR TITLE
Reset environment monitor after shutdown

### DIFF
--- a/tesseract_rviz/src/environment_monitor_properties.cpp
+++ b/tesseract_rviz/src/environment_monitor_properties.cpp
@@ -168,6 +168,7 @@ void EnvironmentMonitorProperties::resetMonitor()
 
   if (data_->monitor != nullptr)
     data_->monitor->shutdown();
+  data_->monitor.reset();
 
   tesseract_gui::EnvironmentManager::remove(data_->component_info);
   data_->render_manager = nullptr;


### PR DESCRIPTION
This fixes this duplicate logging publisher error:

```
[rviz2-7] [WARN] [2026-02-16 09:00:35.673] [rcl.logging_rosout]: Publisher already registered for node name: 'ROSEnvironmentMonitor_internal'. If this is due to multiple nodes with the same name then all logs for the logger named 'rviz.TesseractWorkbench_EnvMonitor_Node.ROSEnvironmentMonitor_internal' will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.
```