### PR TITLE
fix(monitoring): add missing ROSEnvironmentMonitorInterface override

### DIFF
--- a/tesseract_monitoring/src/environment_monitor_interface.cpp
+++ b/tesseract_monitoring/src/environment_monitor_interface.cpp
@@ -356,6 +356,15 @@ bool ROSEnvironmentMonitorInterface::setEnvironmentState(const std::string& moni
   return sendCommands(monitor_namespace, { command });
 }
 
+bool ROSEnvironmentMonitorInterface::setEnvironmentState(const std::string& monitor_namespace,
+                                                         const tesseract::common::TransformMap& floating_joints) const
+{
+  tesseract_msgs::msg::EnvironmentCommand command;
+  command.command = tesseract_msgs::msg::EnvironmentCommand::UPDATE_JOINT_STATE;
+  tesseract_rosutils::toMsg(command.floating_joint_states, floating_joints);
+  return sendCommands(monitor_namespace, { command });
+}
+
 std::vector<std::string>
 ROSEnvironmentMonitorInterface::setEnvironmentState(const std::unordered_map<std::string, double>& joints,
                                                     const tesseract::common::TransformMap& floating_joints) const


### PR DESCRIPTION
Came across this while building nanobind bindings for ROS2EnvironmentMonitor...

Header declared the override final but the cpp never defined it, breaking the vtable when typeinfo is pinned (e.g. nanobind bindings, dynamic_cast). Mirrors the sibling per-namespace overloads.