### PR TITLE
Guard ROSEnvironmentMonitor teardown against a never-initialized executor

### DIFF
--- a/tesseract_monitoring/src/environment_monitor.cpp
+++ b/tesseract_monitoring/src/environment_monitor.cpp
@@ -194,8 +194,15 @@ void ROSEnvironmentMonitor::shutdown()
   get_environment_changes_service_.reset();
   get_environment_information_service_.reset();
   save_scene_graph_service_.reset();
-  internal_node_executor_->cancel();
-  if (internal_node_spinner_->joinable())
+
+  // The executor and spinner are only created at the end of the constructor. If construction bailed
+  // out early (e.g. the robot description parameter was missing, or env_->init() failed because a
+  // package:// mesh could not be resolved), these remain null while the object is otherwise fully
+  // constructed and later destroyed. Dereferencing them unconditionally here segfaults on teardown,
+  // so a failed-to-initialize monitor could not be torn down cleanly. Guard against that.
+  if (internal_node_executor_)
+    internal_node_executor_->cancel();
+  if (internal_node_spinner_ && internal_node_spinner_->joinable())
     internal_node_spinner_->join();
 }
 


### PR DESCRIPTION
## Summary
Null-guard the `ROSEnvironmentMonitor` teardown so a monitor that never finished initializing can exit cleanly on `rclcpp::shutdown()` / SIGTERM instead of segfaulting.

## Root cause
`internal_node_executor_` and `internal_node_spinner_` are created at the very end of the `ROSEnvironmentMonitor` constructor. The `robot_description` constructor returns early if:
- the `robot_description` / `_semantic` parameter is missing, or
- `env_->init(urdf, srdf, locator)` returns `false` — which happens when the URDF cannot be parsed, e.g. a `package://` mesh cannot be resolved (`Environment::init` catches the parse exception and returns `false`).

After such an early return the object is still fully constructed (and later destroyed), but `internal_node_executor_` and `internal_node_spinner_` remain null. `shutdown()` — called from the destructor — then dereferenced them unconditionally:

```cpp
internal_node_executor_->cancel();
if (internal_node_spinner_->joinable())
  internal_node_spinner_->join();
```

so tearing down a failed-to-initialize monitor crashed with a SIGSEGV at a constant offset (the monitor's environment revision never advances past 0). Under a respawn supervisor this turns an intended graceful exit into a crash loop that keeps process-liveness probes green while the monitor never works.

## Fix
Null-check the executor and spinner before use in `shutdown()`, matching the existing null-guarded teardown pattern already used in the same file (`stopStateMonitor`, `stopPublishingEnvironment`). This makes teardown after a failed initialization a no-op.

## Verification
Root cause established at source level: the early constructor return (missing parameter, or `env_->init()` returning `false` on an unresolvable `package://` mesh) leaves `internal_node_executor_` / `internal_node_spinner_` null, and `shutdown()` dereferences them from the destructor — which matches the deterministic constant-offset SIGSEGV observed in our deployment. The fix mirrors the null-guard pattern already used elsewhere in this file and does not change the normal (successfully-initialized) path. A full `colcon` build / runtime repro against current `master` was **not** run in this environment. Happy to provide a symbolized backtrace or add a teardown test if useful.

Closes #195
